### PR TITLE
defaultValues-property-option-validation CSH-5844: validate defaultVa…

### DIFF
--- a/lib/components-schema-v1_0_x.ts
+++ b/lib/components-schema-v1_0_x.ts
@@ -334,11 +334,16 @@ const componentPropertyDefinition = {
             'doc-interactive',
             'doc-link',
         ],
+        description: 'Type of data being stored and how it is used. For directive data types it may also depend on the control type.',
+    },
+    defaultValue: {
+        type: 'string',
+        description: 'Default value of property upon component creation. By default the property value is not defined.',
     },
     group: {type: 'string'},
     selector: {
         type: 'string',
-        description: 'Additional selector to define elements of the component which the property should be applied to',
+        description: 'Additional selector to define elements of the component which the property should be applied to.',
     },
     featureFlag: {
         type: 'string',

--- a/lib/components-types-v1_0_x.ts
+++ b/lib/components-types-v1_0_x.ts
@@ -338,6 +338,9 @@ export interface ComponentsDefinitionV10X {
                       };
                     };
               };
+          /**
+           * Type of data being stored and how it is used. For directive data types it may also depend on the control type.
+           */
           dataType?:
             | "styles"
             | "inlineStyles"
@@ -349,9 +352,13 @@ export interface ComponentsDefinitionV10X {
             | "doc-media"
             | "doc-interactive"
             | "doc-link";
+          /**
+           * Default value of property upon component creation. By default the property value is not defined.
+           */
+          defaultValue?: string;
           group?: string;
           /**
-           * Additional selector to define elements of the component which the property should be applied to
+           * Additional selector to define elements of the component which the property should be applied to.
            */
           selector?: string;
           /**
@@ -668,6 +675,9 @@ export interface ComponentsDefinitionV10X {
                 };
               };
         };
+    /**
+     * Type of data being stored and how it is used. For directive data types it may also depend on the control type.
+     */
     dataType:
       | "styles"
       | "inlineStyles"
@@ -679,9 +689,13 @@ export interface ComponentsDefinitionV10X {
       | "doc-media"
       | "doc-interactive"
       | "doc-link";
+    /**
+     * Default value of property upon component creation. By default the property value is not defined.
+     */
+    defaultValue?: string;
     group?: string;
     /**
-     * Additional selector to define elements of the component which the property should be applied to
+     * Additional selector to define elements of the component which the property should be applied to.
      */
     selector?: string;
     /**

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -15,7 +15,7 @@ import {
     UnitTypeValidator, ImageEditorValidator, FocuspointValidator, DirectivePropertiesValidator, GroupsValidator,
     ConversionRulesValidator, DocSlideshowValidator, DropCapitalValidator, PropertiesValidator, FittingValidator,
     InteractiveValidator, ComponentsValidator, DisableFullscreenCheckboxValidator, SlidesValidator,
-    ScriptsValidator, DocMediaValidator, IconsValidator
+    ScriptsValidator, DocMediaValidator, IconsValidator, DefaultValuesValidator
 } from './validators';
 
 const ajv = new Ajv({allErrors: true, jsonPointers: true, verbose: true});
@@ -121,6 +121,7 @@ export async function validate(
         new ComponentsValidator(filePaths, componentsDefinition),
         new ConversionRulesValidator(parsedDefinition),
         new DefaultComponentOnEnterValidator(parsedDefinition),
+        new DefaultValuesValidator(parsedDefinition),
         new DirectivePropertiesValidator(parsedDefinition),
         new DisableFullscreenCheckboxValidator(componentsDefinition),
         new DocContainerValidator(parsedDefinition),

--- a/lib/parser/parser-utils.ts
+++ b/lib/parser/parser-utils.ts
@@ -104,7 +104,7 @@ export async function parseDefinition(
                         if (!propertyConfiguration) {
                             throw new Error(`Property is not found "${property.name}"`);
                         }
-                        propertyConfiguration = merge(propertyConfiguration, property);
+                        propertyConfiguration = merge({}, propertyConfiguration, property);
                     }
                 } else {
                     // String form refers to an entry in componentProperties. Already validated by json schema.

--- a/lib/validators/default-values-validator.ts
+++ b/lib/validators/default-values-validator.ts
@@ -1,0 +1,103 @@
+/**
+ * Validates if default values for properties are valid.
+ */
+
+import { Validator } from './validator';
+import { ParsedComponentsDefinition,
+    ParsedComponentsDefinitionComponent,
+    ParsedComponentsDefinitionProperty } from '../models';
+
+const validDataTypes = new Set(['styles', 'inlineStyles', 'data']);
+
+export class DefaultValuesValidator implements Validator {
+    private controlTypeToValidateMethod = new Map([
+        ['text', this.validateTextControlValue],
+        ['select', this.validateSelectOrRadioControlValue],
+        ['radio', this.validateSelectOrRadioControlValue],
+        ['checkbox', this.validateCheckboxControlValue],
+    ]);
+
+    constructor(
+        private definition: ParsedComponentsDefinition,
+    ) {
+    }
+
+    validate(
+        errorReporter: (errorMessage: string) => void,
+    ): boolean {
+        return Object.values(this.definition.components).reduce((valid, component) => this.validateComponent(errorReporter, component) && valid, true);
+    }
+
+    /**
+     * Iterate through all properties of given component.
+     *
+     * @param errorReporter
+     * @param component
+     */
+    private validateComponent(errorReporter: (errorMessage: string) => void, component: ParsedComponentsDefinitionComponent) {
+        return component.properties.reduce((valid, property) => this.validateProperty(errorReporter, property) && valid, true);
+    }
+
+    /**
+     * Validate property has a valid dataType for the given default value if any.
+     *
+     * @param errorReporter
+     * @param property
+     */
+    private validateProperty(errorReporter: (errorMessage: string) => void, property: ParsedComponentsDefinitionProperty) {
+        if (!property.defaultValue) {
+            return true;
+        }
+
+        if (!validDataTypes.has(property.dataType)) {
+            errorReporter(`Property ${property.name} has a default value for an unsupported data type ${property.dataType}`);
+            return false;
+        }
+
+        const validateControl = this.controlTypeToValidateMethod.get(property.control.type);
+        if (!validateControl) {
+            errorReporter(`Property ${property.name} has a default value used with an unsupported control type ${property.control.type}`);
+            return false;
+        }
+
+        return validateControl(errorReporter, property);
+    }
+
+    /**
+     * Validate defaultValue against text control type.
+     * @param _errorReporter
+     * @param property
+     */
+    private validateTextControlValue(_errorReporter: (errorMessage: string) => void, property: ParsedComponentsDefinitionProperty) {
+        // Allow any default value for text
+        return true;
+    }
+
+    /**
+     * Validate defaultValue against select or radio control type.
+     *
+     * @param errorReporter
+     * @param property
+     */
+    private validateSelectOrRadioControlValue(errorReporter: (errorMessage: string) => void, property: ParsedComponentsDefinitionProperty) {
+        if (!(<any>property.control).options.find((option: any) => option.value === property.defaultValue)) {
+            errorReporter(`Property ${property.name} defaultValue has no matching entry in ${property.control.type} options`);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Validate defaultValue for checkbox control type.
+     *
+     * @param errorReporter
+     * @param property
+     */
+    private validateCheckboxControlValue(errorReporter: (errorMessage: string) => void, property: ParsedComponentsDefinitionProperty) {
+        if (property.defaultValue !== (<any>property.control).value) {
+            errorReporter(`Property ${property.name} defaultValue does not match ${property.control.type} value`);
+            return false;
+        }
+        return true;
+    }
+}

--- a/lib/validators/index.ts
+++ b/lib/validators/index.ts
@@ -1,6 +1,7 @@
 export * from './components-validator';
 export * from './conversion-rules-validator';
 export * from './default-component-on-enter-validator';
+export * from './default-values-validator';
 export * from './directive-properties-validator';
 export * from './disable-fullscreen-checkbox-validator';
 export * from './doc-container-validator';

--- a/test/validators/default-values-validator.test.ts
+++ b/test/validators/default-values-validator.test.ts
@@ -1,0 +1,205 @@
+import { DefaultValuesValidator } from '../../lib/validators/default-values-validator';
+
+describe('DefaultValuesValidator', () => {
+    let definition: any;
+    let validator: DefaultValuesValidator;
+    let reporter: jasmine.Spy;
+
+    beforeEach(() => {
+        // valid definition (cut)
+        definition = {
+            'components': {
+                'text': {
+                    'component': {
+                        'name': 'text',
+                    },
+                    'properties': [],
+                },
+            },
+        };
+        reporter = jasmine.createSpy('reporter');
+    });
+    describe('validate', () => {
+        it('should pass validation if property has no defaultValue set', () => {
+            validator = new DefaultValuesValidator(definition);
+            const valid = validator.validate(reporter);
+
+            expect(reporter).not.toHaveBeenCalled();
+            expect(valid).toBe(true);
+        });
+
+        ['styles', 'inlineStyles', 'data'].forEach((dataType) => {
+            it(`should pass with defaultValue for data type ${dataType}`, () => {
+                definition.components.text.properties.push({
+                    name: 'propertyName',
+                    defaultValue: 'value',
+                    dataType: dataType,
+                    control: { type: 'text' },
+                });
+
+                validator = new DefaultValuesValidator(definition);
+                const valid = validator.validate(reporter);
+
+                expect(reporter).not.toHaveBeenCalled();
+                expect(valid).toBe(true);
+            });
+        });
+
+        it('should not pass validation with defaultValue for unsupported dataType', () => {
+            definition.components.text.properties.push({
+                name: 'propertyName',
+                defaultValue: 'value',
+                dataType: 'doc-editable',
+                control: { type: 'text' },
+            });
+
+            validator = new DefaultValuesValidator(definition);
+            const valid = validator.validate(reporter);
+
+            expect(reporter).toHaveBeenCalledWith(
+                'Property propertyName has a default value for an unsupported data type doc-editable');
+            expect(valid).toBe(false);
+        });
+
+        it('should not pass with unsupported control type', () => {
+            definition.components.text.properties.push({
+                name: 'propertyName',
+                defaultValue: 'value',
+                dataType: 'styles',
+                control: {
+                    type: 'unsupported',
+                },
+            });
+
+            validator = new DefaultValuesValidator(definition);
+            const valid = validator.validate(reporter);
+
+            expect(reporter).toHaveBeenCalledWith(
+                'Property propertyName has a default value used with an unsupported control type unsupported');
+            expect(valid).toBe(false);
+        });
+
+        it('should pass with control type select and defaultValue being present in options', () => {
+            definition.components.text.properties.push({
+                name: 'propertyName',
+                defaultValue: 'value',
+                dataType: 'styles',
+                control: {
+                    type: 'select',
+                    options: [
+                        { caption: '1' },
+                        { caption: '2', value: 'value' },
+                    ],
+                },
+            });
+
+            validator = new DefaultValuesValidator(definition);
+            const valid = validator.validate(reporter);
+
+            expect(reporter).not.toHaveBeenCalled();
+            expect(valid).toBe(true);
+        });
+
+        it('should not pass with control type select and defaultValue not being present in options', () => {
+            definition.components.text.properties.push({
+                name: 'propertyName',
+                defaultValue: 'value',
+                dataType: 'styles',
+                control: {
+                    type: 'select',
+                    options: [
+                        { caption: '1' },
+                        { caption: '2', value: 'other-value' },
+                    ],
+                },
+            });
+
+            validator = new DefaultValuesValidator(definition);
+            const valid = validator.validate(reporter);
+
+            expect(reporter).toHaveBeenCalledWith(
+                'Property propertyName defaultValue has no matching entry in select options');
+            expect(valid).toBe(false);
+        });
+
+        it('should pass with control type radio and defaultValue being present in options', () => {
+            definition.components.text.properties.push({
+                name: 'propertyName',
+                defaultValue: 'value',
+                dataType: 'styles',
+                control: {
+                    type: 'radio',
+                    options: [
+                        { caption: '1' },
+                        { caption: '2', value: 'value' },
+                    ],
+                },
+            });
+
+            validator = new DefaultValuesValidator(definition);
+            const valid = validator.validate(reporter);
+
+            expect(reporter).not.toHaveBeenCalled();
+            expect(valid).toBe(true);
+        });
+
+        it('should not pass with control type radio and defaultValue not being present in options', () => {
+            definition.components.text.properties.push({
+                name: 'propertyName',
+                defaultValue: 'value',
+                dataType: 'styles',
+                control: {
+                    type: 'radio',
+                    options: [
+                        { caption: '1' },
+                        { caption: '2', value: 'other-value' },
+                    ],
+                },
+            });
+
+            validator = new DefaultValuesValidator(definition);
+            const valid = validator.validate(reporter);
+
+            expect(reporter).toHaveBeenCalledWith(
+                'Property propertyName defaultValue has no matching entry in radio options');
+            expect(valid).toBe(false);
+        });
+
+        it('should pass with control type checkbox and defaultValue being the checked value', () => {
+            definition.components.text.properties.push({
+                name: 'propertyName',
+                defaultValue: 'value',
+                dataType: 'styles',
+                control: {
+                    type: 'checkbox',
+                    value: 'value',
+                },
+            });
+
+            validator = new DefaultValuesValidator(definition);
+            const valid = validator.validate(reporter);
+
+            expect(reporter).not.toHaveBeenCalled();
+            expect(valid).toBe(true);
+        });
+
+        it('should pass with control type checkbox and defaultValue being the checked value', () => {
+            definition.components.text.properties.push({
+                name: 'propertyName',
+                defaultValue: 'value',
+                dataType: 'styles',
+                control: {
+                    type: 'checkbox',
+                    value: 'other-value',
+                },
+            });
+
+            validator = new DefaultValuesValidator(definition);
+            const valid = validator.validate(reporter);
+
+            expect(reporter).toHaveBeenCalledWith(
+                'Property propertyName defaultValue does not match checkbox value');
+            expect(valid).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
…lue which can only be used for certain data types and control types. Fix bug in parser utils that would incorrectly merge properties into components.