### PR TITLE
simplify-error-code CSH-5855: remove need for returning a boolean val…

### DIFF
--- a/lib/validators/autofill-validator.ts
+++ b/lib/validators/autofill-validator.ts
@@ -8,19 +8,19 @@ import { DirectiveType, ParsedComponentsDefinitionV11X } from '../models';
 const supportedDestinationDirectives = [DirectiveType.editable, DirectiveType.link];
 const supportedSourceDirectives = [DirectiveType.image];
 
-export class AutofillValidator implements Validator {
+export class AutofillValidator extends Validator {
 
     constructor(
+        error: (errorMessage: string) => false,
         private definition: ParsedComponentsDefinitionV11X,
     ) {
+        super(error);
     }
 
-    validate(
-        errorReporter: (errorMessage: string) => void,
-    ): boolean {
-        return Object.values(this.definition.components).reduce((valid, component) => {
-            return this.validateComponent(errorReporter, component) && valid;
-        }, true);
+    validate(): void {
+        Object.values(this.definition.components).forEach((component) => {
+            this.validateComponent(component);
+        });
     }
 
     /**
@@ -34,15 +34,12 @@ export class AutofillValidator implements Validator {
      * @param parsedComponent
      */
     validateComponent(
-        errorReporter: (errorMessage: string) => void,
         parsedComponent: ParsedComponentsDefinitionV11X['components']['name'],
-    ): boolean {
+    ): void {
         // Only check when it has directiveOptions configured
         if (!parsedComponent.component.directiveOptions) {
-            return true;
+            return;
         }
-
-        let valid = true;
 
         for (const [dstKey, directiveOptions] of Object.entries(parsedComponent.component.directiveOptions)) {
             // Only for directives with autofill
@@ -54,39 +51,31 @@ export class AutofillValidator implements Validator {
 
             // check if destination directive exists
             if (!parsedComponent.directives[dstKey]) {
-                errorReporter(`Component "${parsedComponent.component.name}" has incorrect autofill rule "${dstKey}". ` +
+                this.error(`Component "${parsedComponent.component.name}" has incorrect autofill rule "${dstKey}". ` +
                 `This component doesn't have directive "${dstKey}".`);
-                valid = false;
             } else if (supportedDestinationDirectives.indexOf(parsedComponent.directives[dstKey].type) < 0) {
-                errorReporter(`Component "${parsedComponent.component.name}" has incorrect autofill rule "${dstKey}". ` +
+                this.error(`Component "${parsedComponent.component.name}" has incorrect autofill rule "${dstKey}". ` +
                 `Supported types of destination directive are "${supportedDestinationDirectives.join('", "')}" only.`);
-                valid = false;
             }
 
             // check if source directive exists
             if (!parsedComponent.directives[rule.source]) {
-                errorReporter(`Component "${parsedComponent.component.name}" has incorrect autofill rule "${dstKey}". ` +
+                this.error(`Component "${parsedComponent.component.name}" has incorrect autofill rule "${dstKey}". ` +
                 `This component doesn't have directive "${rule.source}".`);
-                valid = false;
             // Check if source directive is supported
             } else if (supportedSourceDirectives.indexOf(parsedComponent.directives[rule.source].type) < 0) {
-                errorReporter(`Component "${parsedComponent.component.name}" has incorrect autofill rule "${dstKey}". ` +
+                this.error(`Component "${parsedComponent.component.name}" has incorrect autofill rule "${dstKey}". ` +
                 `Supported types of source directive are "${supportedSourceDirectives.join('", "')}" only.`);
-                valid = false;
             // check if metadataField is set when source directive is image kind
             } else if (parsedComponent.directives[rule.source].type === DirectiveType.image && !('metadataField' in rule)) {
-                errorReporter(`Component "${parsedComponent.component.name}" has incorrect autofill rule "${dstKey}". ` +
+                this.error(`Component "${parsedComponent.component.name}" has incorrect autofill rule "${dstKey}". ` +
                 `If source directive is image kind then "metadataField" must be set.`);
-                valid = false;
             }
             // check if dst !== src
             if (dstKey === rule.source) {
-                errorReporter(`Component "${parsedComponent.component.name}" has incorrect autofill rule "${dstKey}". ` +
+                this.error(`Component "${parsedComponent.component.name}" has incorrect autofill rule "${dstKey}". ` +
                 `There is no sense to fill directive content from itself.`);
-                valid = false;
             }
         }
-
-        return valid;
     }
 }

--- a/lib/validators/components-validator.ts
+++ b/lib/validators/components-validator.ts
@@ -20,63 +20,55 @@ const GENERIC_FILES = [
     path.normalize('./styles/design.css'),
 ];
 
-export class ComponentsValidator implements Validator {
+export class ComponentsValidator extends Validator {
 
     constructor(
+        error: (errorMessage: string) => false,
         private filePaths: Set<string>,
         private definition: ComponentsDefinition,
     ) {
+        super(error);
     }
 
-    validate(
-        errorReporter: (errorMessage: string) => void,
-    ): boolean {
+    validate(): void {
         let valid = true;
 
         const componentNames = new Set<string>();
         for (const comp of this.definition.components) {
             // reserved words
             if (RESERVED.some(regexp => regexp.test(comp.name))) {
-                errorReporter(`Component name "${comp.name}" is a reserved word`);
-                valid = false;
+                this.error(`Component name "${comp.name}" is a reserved word`);
             }
 
             // Validate we have not seen the name yet
             if (componentNames.has(comp.name)) {
-                valid = false;
-                errorReporter(`Component "${comp.name}" is not unique`);
+                this.error(`Component "${comp.name}" is not unique`);
             }
             componentNames.add(comp.name);
 
             // Validate the component has an icon
             if (!this.filePaths.has(path.normalize(comp.icon))) {
-                valid = false;
-                errorReporter(`Component "${comp.name}" icon missing "${comp.icon}"`);
+                this.error(`Component "${comp.name}" icon missing "${comp.icon}"`);
             }
 
             // Validate the component has a html template
             const htmlTemplatePath = path.normalize(`./templates/html/${comp.name}.html`);
             if (!this.filePaths.has(htmlTemplatePath)) {
-                valid = false;
-                errorReporter(`Component "${comp.name}" html template missing "${htmlTemplatePath}"`);
+                this.error(`Component "${comp.name}" html template missing "${htmlTemplatePath}"`);
             }
 
             // Validate the component has a style
             const componentStylePath = path.normalize(`./styles/_${comp.name}.scss`);
             if (!this.filePaths.has(componentStylePath)) {
-                valid = false;
-                errorReporter(`Component "${comp.name}" style scss file missing "${componentStylePath}"`);
+                this.error(`Component "${comp.name}" style scss file missing "${componentStylePath}"`);
             }
         }
 
         // generic files
         for (const file of GENERIC_FILES) {
             if (!this.filePaths.has(file)) {
-                valid = false;
-                errorReporter(`File "${file}" is missing`);
+                this.error(`File "${file}" is missing`);
             }
         }
-
-        return valid;
     }
 }

--- a/lib/validators/conversion-rules-validator.ts
+++ b/lib/validators/conversion-rules-validator.ts
@@ -5,28 +5,24 @@
 import { Validator } from './validator';
 import { ParsedComponentsDefinitionV10X, DirectiveType } from '../models';
 
-export class ConversionRulesValidator implements Validator {
+export class ConversionRulesValidator extends Validator {
 
     constructor(
+        error: (errorMessage: string) => false,
         private definition: ParsedComponentsDefinitionV10X,
     ) {
+        super(error);
     }
 
-    validate(
-        errorReporter: (errorMessage: string) => void,
-    ): boolean {
-        let valid = true;
-
+    validate(): void {
         for (const srcComponentName of Object.keys(this.definition.conversionRules)) {
             if (!(srcComponentName in this.definition.components)) {
-                errorReporter(`Conversion rule references to non existing component "${srcComponentName}"`);
-                valid = false;
+                this.error(`Conversion rule references to non existing component "${srcComponentName}"`);
                 continue;   // stop checking
             }
             for (const dstComponentName of Object.keys(this.definition.conversionRules[srcComponentName])) {
                 if (!(dstComponentName in this.definition.components)) {
-                    errorReporter(`Conversion rule references to non existing component "${dstComponentName}"`);
-                    valid = false;
+                    this.error(`Conversion rule references to non existing component "${dstComponentName}"`);
                     continue;   // stop checking
                 }
                 const rule = this.definition.conversionRules[srcComponentName][dstComponentName];
@@ -38,13 +34,11 @@ export class ConversionRulesValidator implements Validator {
                 if (rule.type === 'simple') {
                     for (const dstDirectiveKey of Object.keys(rule.map)) {
                         if (!(dstDirectiveKey in this.definition.components[dstComponentName].directives)) {
-                            errorReporter(`Conversion rule references to non existing directive "${dstDirectiveKey}"`);
-                            valid = false;
+                            this.error(`Conversion rule references to non existing directive "${dstDirectiveKey}"`);
                         }
                         const srcDirectiveKey = rule.map[dstDirectiveKey];
                         if (!(srcDirectiveKey in this.definition.components[srcComponentName].directives)) {
-                            errorReporter(`Conversion rule references to non existing directive "${srcDirectiveKey}"`);
-                            valid = false;
+                            this.error(`Conversion rule references to non existing directive "${srcDirectiveKey}"`);
                         }
                     }
                     continue;   // stop checking
@@ -52,34 +46,28 @@ export class ConversionRulesValidator implements Validator {
                 if (rule.type === 'from-container') {
                     const srcDirectiveKey = rule.container;
                     if (!(srcDirectiveKey in this.definition.components[srcComponentName].directives)) {
-                        errorReporter(`Conversion rule references to non existing directive "${srcDirectiveKey}"`);
-                        valid = false;
+                        this.error(`Conversion rule references to non existing directive "${srcDirectiveKey}"`);
                         continue;   // stop checking
                     }
                     const srcDirectiveType = this.definition.components[srcComponentName].directives[srcDirectiveKey].type;
                     if (![DirectiveType.container, DirectiveType.slideshow].some(type => type === srcDirectiveType)) {
-                        errorReporter(`Conversion rule references to a directive "${srcDirectiveKey}" which must be "slideshow" or "container"`);
-                        valid = false;
+                        this.error(`Conversion rule references to a directive "${srcDirectiveKey}" which must be "slideshow" or "container"`);
                     }
                     continue;   // stop checking
                 }
                 if (rule.type === 'to-container') {
                     const dstDirectiveKey = rule.container;
                     if (!(dstDirectiveKey in this.definition.components[dstComponentName].directives)) {
-                        errorReporter(`Conversion rule references to non existing directive "${dstDirectiveKey}"`);
-                        valid = false;
+                        this.error(`Conversion rule references to non existing directive "${dstDirectiveKey}"`);
                         continue;   // stop checking
                     }
                     const dstDirectiveType = this.definition.components[dstComponentName].directives[dstDirectiveKey].type;
                     if (![DirectiveType.container, DirectiveType.slideshow].some(type => type === dstDirectiveType)) {
-                        errorReporter(`Conversion rule references to a directive "${dstDirectiveKey}" which must be "slideshow" or "container"`);
-                        valid = false;
+                        this.error(`Conversion rule references to a directive "${dstDirectiveKey}" which must be "slideshow" or "container"`);
                     }
                     continue;   // stop checking
                 }
             }
         }
-        
-        return valid;
     }
 }

--- a/lib/validators/default-component-on-enter-override-validator.ts
+++ b/lib/validators/default-component-on-enter-override-validator.ts
@@ -5,28 +5,23 @@
 import { Validator } from './validator';
 import { ParsedComponentsDefinitionV11X } from '../models';
 
-export class DefaultComponentOnEnterOverrideValidator implements Validator {
+export class DefaultComponentOnEnterOverrideValidator extends Validator {
 
     constructor(
+        error: (errorMessage: string) => false,
         private definition: ParsedComponentsDefinitionV11X,
     ) {
+        super(error);
     }
 
-    validate(
-        errorReporter: (errorMessage: string) => void,
-    ): boolean {
-        let valid = true;
-
+    validate(): void {
         for (const parsedComponent of Object.values(this.definition.components)) {
             if ('defaultComponentOnEnter' in parsedComponent.component &&
                 parsedComponent.component.defaultComponentOnEnter &&
                 !(parsedComponent.component.defaultComponentOnEnter in this.definition.components)
             ) {
-                errorReporter(`Property "defaultComponentOnEnter" of "${parsedComponent.component.name}" points to non existing component "${parsedComponent.component.defaultComponentOnEnter}"`);
-                valid = false;
+                this.error(`Property "defaultComponentOnEnter" of "${parsedComponent.component.name}" points to non existing component "${parsedComponent.component.defaultComponentOnEnter}"`);
             }
         }
-
-        return valid;
     }
 }

--- a/lib/validators/default-component-on-enter-validator.ts
+++ b/lib/validators/default-component-on-enter-validator.ts
@@ -5,23 +5,18 @@
 import { Validator } from './validator';
 import { ParsedComponentsDefinitionV10X } from '../models';
 
-export class DefaultComponentOnEnterValidator implements Validator {
+export class DefaultComponentOnEnterValidator extends Validator {
 
     constructor(
+        error: (errorMessage: string) => false,
         private definition: ParsedComponentsDefinitionV10X,
     ) {
+        super(error);
     }
 
-    validate(
-        errorReporter: (errorMessage: string) => void,
-    ): boolean {
-        let valid = true;
-
+    validate(): void {
         if (!(this.definition.defaultComponentOnEnter in this.definition.components)) {
-            errorReporter(`Property "defaultComponentOnEnter" points to non existing component "${this.definition.defaultComponentOnEnter}"`);
-            valid = false;
+            this.error(`Property "defaultComponentOnEnter" points to non existing component "${this.definition.defaultComponentOnEnter}"`);
         }
-
-        return valid;
     }
 }

--- a/lib/validators/directive-properties-validator.ts
+++ b/lib/validators/directive-properties-validator.ts
@@ -9,35 +9,30 @@ import { ParsedComponentsDefinitionV10X, DirectiveType } from '../models';
 
 const CONTROLS = ['image-editor', 'interactive', 'media-properties'];
 
-export class DirectivePropertiesValidator implements Validator {
+export class DirectivePropertiesValidator extends Validator {
 
     constructor(
+        error: (errorMessage: string) => false,
         private definition: ParsedComponentsDefinitionV10X,
     ) {
+        super(error);
     }
 
-    validate(
-        errorReporter: (errorMessage: string) => void,
-    ): boolean {
-        let valid = true;
+    validate(): void {
         const regexp = new RegExp(`^doc-(${Object.values(DirectiveType).filter(item => item !== DirectiveType.unknown).join('|')})`, 'i');
 
         for (const parsedComponent of Object.values(this.definition.components)) {
             parsedComponent.properties.forEach((parsedProperty) => {
                 if (CONTROLS.indexOf(parsedProperty.control.type) >= 0 && !parsedProperty.directiveKey) {
-                    errorReporter(`Property "${parsedProperty.name}" of component "${parsedComponent.component.name}" must reference ` +
+                    this.error(`Property "${parsedProperty.name}" of component "${parsedComponent.component.name}" must reference ` +
                         `to a directive`);
-                    valid = false;
                 }
                 // check all dataType=doc-* properties
                 if (regexp.test(parsedProperty.dataType) && !parsedProperty.directiveKey) {
-                    errorReporter(`Property "${parsedProperty.name}" of component "${parsedComponent.component.name}" must reference ` +
+                    this.error(`Property "${parsedProperty.name}" of component "${parsedComponent.component.name}" must reference ` +
                         `to a directive because its dataType is a directive type`);
-                    valid = false;
                 }
             });
         }
-
-        return valid;
     }
 }

--- a/lib/validators/disable-fullscreen-checkbox-validator.ts
+++ b/lib/validators/disable-fullscreen-checkbox-validator.ts
@@ -8,26 +8,21 @@ import { ComponentsDefinition } from '../models';
 const CONTROL = 'disable-fullscreen-checkbox';
 const ALLOWED_DATA_TYPE = 'styles';
 
-export class DisableFullscreenCheckboxValidator implements Validator {
+export class DisableFullscreenCheckboxValidator extends Validator {
 
     constructor(
+        error: (errorMessage: string) => false,
         private definition: ComponentsDefinition,
     ) {
+        super(error);
     }
 
-    validate(
-        errorReporter: (errorMessage: string) => void,
-    ): boolean {
-        let valid = true;
-
+    validate(): void {
         for (const property of this.definition.componentProperties) {
             if (property.control.type === CONTROL && property.dataType !== ALLOWED_DATA_TYPE) {
-                errorReporter(`Property "${property.name}" uses "${CONTROL}" control type which is allowed to use with ` +
+                this.error(`Property "${property.name}" uses "${CONTROL}" control type which is allowed to use with ` +
                     `dataType="${ALLOWED_DATA_TYPE}" only`);
-                valid = false;
             }
         }
-
-        return valid;
     }
 }

--- a/lib/validators/doc-slideshow-validator.ts
+++ b/lib/validators/doc-slideshow-validator.ts
@@ -5,11 +5,24 @@
 import { Validator } from './validator';
 import { DirectiveType, ParsedComponentsDefinitionV10X, ParsedComponentsDefinitionComponent, ParsedComponentsDefinitionDirective } from '../models';
 
-export class DocSlideshowValidator implements Validator {
+export class DocSlideshowValidator extends Validator {
 
     constructor(
+        error: (errorMessage: string) => false,
         private definition: ParsedComponentsDefinitionV10X,
     ) {
+        super(error);
+    }
+
+    validate(): void {
+        Object.values(this.definition.components).forEach((parsedComponent: ParsedComponentsDefinitionComponent) => {
+            const amountOfSlideshows = this.countSlideshowDirectives(parsedComponent);
+            // check if it's the only one
+            if (amountOfSlideshows > 1) {
+                this.error(`Component "${parsedComponent.component.name}" contains more then one slideshow directive, ` +
+                    `only one is allowed per component`);
+            }
+        });
     }
 
     private countSlideshowDirectives(parsedComponent: ParsedComponentsDefinitionComponent) : number {
@@ -20,23 +33,5 @@ export class DocSlideshowValidator implements Validator {
             }
             return acc;
         }, 0);
-    }
-
-    validate(
-        errorReporter: (errorMessage: string) => void,
-    ): boolean {
-        let valid = true;
-
-        Object.values(this.definition.components).forEach((parsedComponent: ParsedComponentsDefinitionComponent) => {
-            const amountOfSlideshows = this.countSlideshowDirectives(parsedComponent);
-            // check if it's the only one
-            if (amountOfSlideshows > 1) {
-                errorReporter(`Component "${parsedComponent.component.name}" contains more then one slideshow directive, ` +
-                    `only one is allowed per component`);
-                valid = false;
-            }
-        });
-
-        return valid;
     }
 }

--- a/lib/validators/drop-capital-validator.ts
+++ b/lib/validators/drop-capital-validator.ts
@@ -10,12 +10,14 @@ import { ComponentsDefinition, ParsedComponentsDefinitionV10X, ParsedComponentsD
 const CONTROL = 'drop-capital';
 const ALLOWED_DATA_TYPE = 'data';
 
-export class DropCapitalValidator implements Validator {
+export class DropCapitalValidator extends Validator {
 
     constructor(
+        error: (errorMessage: string) => false,
         private definition: ComponentsDefinition,
         private parsedDefinition: ParsedComponentsDefinitionV10X,
     ) {
+        super(error);
     }
 
     private countPerComponent(component: ParsedComponentsDefinitionComponent) : number {
@@ -28,27 +30,19 @@ export class DropCapitalValidator implements Validator {
         return amount;
     }
 
-    validate(
-        errorReporter: (errorMessage: string) => void,
-    ): boolean {
-        let valid = true;
-
+    validate(): void {
         for (const property of this.definition.componentProperties) {
             if (property.control.type === CONTROL && property.dataType !== ALLOWED_DATA_TYPE) {
-                errorReporter(`Property "${property.name}" uses "${CONTROL}" control type which is allowed to use with ` +
+                this.error(`Property "${property.name}" uses "${CONTROL}" control type which is allowed to use with ` +
                     `dataType="${ALLOWED_DATA_TYPE}" only`);
-                valid = false;
             }
         }
 
         for (const parsedComponent of Object.values(this.parsedDefinition.components)) {
             if (this.countPerComponent(parsedComponent) > 1) {
-                errorReporter(`Component "${parsedComponent.component.name}" uses properties with "${CONTROL}" control type ` +
+                this.error(`Component "${parsedComponent.component.name}" uses properties with "${CONTROL}" control type ` +
                     `more that one time`);
-                valid = false;
             }
         }
-
-        return valid;
     }
 }

--- a/lib/validators/fitting-validator.ts
+++ b/lib/validators/fitting-validator.ts
@@ -8,11 +8,13 @@ import { ParsedComponentsDefinitionV10X, ParsedComponentsDefinitionComponent } f
 
 const CONTROL = 'fitting';
 
-export class FittingValidator implements Validator {
+export class FittingValidator extends Validator {
 
     constructor(
+        error: (errorMessage: string) => false,
         private parsedDefinition: ParsedComponentsDefinitionV10X,
     ) {
+        super(error);
     }
 
     private countPerComponent(component: ParsedComponentsDefinitionComponent) : number {
@@ -25,19 +27,12 @@ export class FittingValidator implements Validator {
         return amount;
     }
 
-    validate(
-        errorReporter: (errorMessage: string) => void,
-    ): boolean {
-        let valid = true;
-
+    validate(): void {
         for (const parsedComponent of Object.values(this.parsedDefinition.components)) {
             if (this.countPerComponent(parsedComponent) > 1) {
-                errorReporter(`Component "${parsedComponent.component.name}" uses properties with "${CONTROL}" control type ` +
+                this.error(`Component "${parsedComponent.component.name}" uses properties with "${CONTROL}" control type ` +
                     `more that one time`);
-                valid = false;
             }
         }
-
-        return valid;
     }
 }

--- a/lib/validators/focuspoint-validator.ts
+++ b/lib/validators/focuspoint-validator.ts
@@ -5,32 +5,27 @@
 import { Validator } from './validator';
 import { ParsedComponentsDefinitionV10X } from '../models';
 
-export class FocuspointValidator implements Validator {
+export class FocuspointValidator extends Validator {
 
     constructor(
+        error: (errorMessage: string) => false,
         private definition: ParsedComponentsDefinitionV10X,
     ) {
+        super(error);
     }
 
-    validate(
-        errorReporter: (errorMessage: string) => void,
-    ): boolean {
-        let valid = true;
-
+    validate(): void {
         for (const parsedComponent of Object.values(this.definition.components)) {
             parsedComponent.properties.forEach((parsedProperty) => {
                 if (parsedProperty.control.type === 'image-editor' && parsedProperty.control.focuspoint &&
                     parsedProperty.directiveKey &&  // skip, it's covered in other validator
                     parsedComponent.directives[parsedProperty.directiveKey] && // skip, it's covered in other validator
                     parsedComponent.directives[parsedProperty.directiveKey].tag === 'img') {
-                        errorReporter(`Property "${parsedProperty.name}" of component "${parsedComponent.component.name}" uses ` +
+                        this.error(`Property "${parsedProperty.name}" of component "${parsedComponent.component.name}" uses ` +
                             `"focuspoint" feature on <img> html tag, which is not supported, "focuspoint" can be applied to other html tags, where` +
                             `image is a background`);
-                        valid = false;
                     }
             });
         }
-
-        return valid;
     }
 }

--- a/lib/validators/groups-validator.ts
+++ b/lib/validators/groups-validator.ts
@@ -5,17 +5,17 @@
 import { Validator } from './validator';
 import { ParsedComponentsDefinitionV10X } from '../models';
 
-export class GroupsValidator implements Validator {
+export class GroupsValidator extends Validator {
 
     constructor(
+        error: (errorMessage: string) => false,
         private definition: ParsedComponentsDefinitionV10X,
     ) {
+        super(error);
     }
 
-    validate(
-        errorReporter: (errorMessage: string) => void,
-    ): boolean {
-        return this.validateGroupsList(errorReporter, this.definition.groups);
+    validate(): void {
+        this.validateGroupsList(this.definition.groups);
     }
 
     /**
@@ -25,24 +25,18 @@ export class GroupsValidator implements Validator {
      * @param parsedGroup
      */
     validateGroupsList(
-        errorReporter: (errorMessage: string) => void,
         groups: ParsedComponentsDefinitionV10X['groups'],
-    ): boolean {
-        let valid = true;
-
+    ): void {
         const groupNames = new Set<string>();
 
         for (const group of groups) {
-            valid = this.validateGroup(errorReporter, group) && valid;
+            this.validateGroup(group);
 
             if (groupNames.has(group.name)) {
-                valid = false;
-                errorReporter(`Component group "${group.name}" is not unique`);
+                this.error(`Component group "${group.name}" is not unique`);
             }
             groupNames.add(group.name);
         }
-
-        return valid;
     }
 
     /**
@@ -52,18 +46,12 @@ export class GroupsValidator implements Validator {
      * @param parsedGroup
      */
     private validateGroup(
-        errorReporter: (errorMessage: string) => void,
         group: ParsedComponentsDefinitionV10X['groups'][0],
-    ): boolean {
-        let valid = true;
-
+    ): void {
         for (const componentName of group.components) {
             if (!(componentName in this.definition.components)) {
-                errorReporter(`Component "${componentName}" of group "${group.name}" does not exist`);
-                valid = false;
+                this.error(`Component "${componentName}" of group "${group.name}" does not exist`);
             }
         }
-
-        return valid;
     }
 }

--- a/lib/validators/icons-validator.ts
+++ b/lib/validators/icons-validator.ts
@@ -9,37 +9,31 @@ import { ComponentsDefinition } from '../models';
 import { GetFileContentType } from '..';
 var PNG = require('pngjs').PNG;
 
-export class IconsValidator implements Validator {
+export class IconsValidator extends Validator {
 
     private supportedFormats = ['.svg', '.png'];
 
     constructor(
+        error: (errorMessage: string) => false,
         private definition: ComponentsDefinition,
         private getFileContent: GetFileContentType,
     ) {
+        super(error);
     }
 
-    async validate(
-        errorReporter: (errorMessage: string) => void,
-    ): Promise<boolean> {
-        let valid = true;
-
+    async validate(): Promise<void> {
         for (const component of Object.values(this.definition.components)) {
             const ext = path.extname(component.icon).toLowerCase();
             if (this.supportedFormats.indexOf(ext) === -1) {
-                errorReporter(`Icons are only supported in SVG or transparent PNG format`);
-                valid = false;
+                this.error(`Icons are only supported in SVG or transparent PNG format`);
             } else if (ext === '.png') {
                 let data = await this.getFileContent(path.normalize(component.icon));
                 let png = PNG.sync.read(data);
 
                 if (png.alpha === false) {
-                    valid = false;
-                    errorReporter(`PNG icons are only supported when they are transparent`);
+                    this.error(`PNG icons are only supported when they are transparent`);
                 }
             }
         }
-
-        return valid;
     }
 }

--- a/lib/validators/image-editor-validator.ts
+++ b/lib/validators/image-editor-validator.ts
@@ -8,26 +8,21 @@ import { ComponentsDefinition } from '../models';
 const CONTROL = 'image-editor';
 const ALLOWED_DATA_TYPE = 'doc-image';
 
-export class ImageEditorValidator implements Validator {
+export class ImageEditorValidator extends Validator {
 
     constructor(
+        error: (errorMessage: string) => false,
         private definition: ComponentsDefinition,
     ) {
+        super(error);
     }
 
-    validate(
-        errorReporter: (errorMessage: string) => void,
-    ): boolean {
-        let valid = true;
-
+    validate(): void {
         for (const property of this.definition.componentProperties) {
             if (property.control.type === CONTROL && property.dataType !== ALLOWED_DATA_TYPE) {
-                errorReporter(`Property "${property.name}" uses "${CONTROL}" control type which is allowed to use with ` +
+                this.error(`Property "${property.name}" uses "${CONTROL}" control type which is allowed to use with ` +
                     `dataType="${ALLOWED_DATA_TYPE}" only`);
-                valid = false;
             }
         }
-
-        return valid;
     }
 }

--- a/lib/validators/interactive-validator.ts
+++ b/lib/validators/interactive-validator.ts
@@ -8,26 +8,21 @@ import { ComponentsDefinition } from '../models';
 const CONTROL = 'interactive';
 const ALLOWED_DATA_TYPE = 'doc-interactive';
 
-export class InteractiveValidator implements Validator {
+export class InteractiveValidator extends Validator {
 
     constructor(
+        error: (errorMessage: string) => false,
         private definition: ComponentsDefinition,
     ) {
+        super(error);
     }
 
-    validate(
-        errorReporter: (errorMessage: string) => void,
-    ): boolean {
-        let valid = true;
-
+    validate(): void {
         for (const property of this.definition.componentProperties) {
             if (property.control.type === CONTROL && property.dataType !== ALLOWED_DATA_TYPE) {
-                errorReporter(`Property "${property.name}" uses "${CONTROL}" control type which is allowed to use with ` +
+                this.error(`Property "${property.name}" uses "${CONTROL}" control type which is allowed to use with ` +
                     `dataType="${ALLOWED_DATA_TYPE}" only`);
-                valid = false;
             }
         }
-
-        return valid;
     }
 }

--- a/lib/validators/properties-validator.ts
+++ b/lib/validators/properties-validator.ts
@@ -14,31 +14,27 @@ const RESERVED = [
     /^parallax$/,
 ];
 
-export class PropertiesValidator implements Validator {
+export class PropertiesValidator extends Validator {
 
     constructor(
+        error: (errorMessage: string) => false,
         private filePaths: Set<string>,
         private definition: ComponentsDefinition,
     ) {
+        super(error);
     }
 
-    validate(
-        errorReporter: (errorMessage: string) => void,
-    ): boolean {
-        let valid = true;
-
+    validate(): void {
         // Check component properties
         const componentPropertyNames = new Set<string>();
         for (const compProp of this.definition.componentProperties) {
             // reserved words
             if (RESERVED.some(regexp => regexp.test(compProp.name))) {
-                errorReporter(`Component property name "${compProp.name}" is a reserved word`);
-                valid = false;
+                this.error(`Component property name "${compProp.name}" is a reserved word`);
             }
             // Validate we have not seen the name yet
             if (componentPropertyNames.has(compProp.name)) {
-                errorReporter(`Component property "${compProp.name}" is not unique`);
-                valid = false;
+                this.error(`Component property "${compProp.name}" is not unique`);
             }
             componentPropertyNames.add(compProp.name);
 
@@ -46,13 +42,10 @@ export class PropertiesValidator implements Validator {
             if (compProp.control.type === 'radio') {
                 for (const controlOption of compProp.control.options) {
                     if (!this.filePaths.has(path.normalize(controlOption.icon))) {
-                        errorReporter(`Component properties "${compProp.name}" icon missing "${controlOption.icon}"`);
-                        valid = false;
+                        this.error(`Component properties "${compProp.name}" icon missing "${controlOption.icon}"`);
                     }
                 }
             }
         }
-
-        return valid;
     }
 }

--- a/lib/validators/scripts-validator.ts
+++ b/lib/validators/scripts-validator.ts
@@ -6,28 +6,23 @@ import * as path from 'path';
 import { Validator } from './validator';
 import { ComponentsDefinition } from '../models';
 
-export class ScriptsValidator implements Validator {
+export class ScriptsValidator extends Validator {
 
     constructor(
+        error: (errorMessage: string) => false,
         private filePaths: Set<string>,
         private definition: ComponentsDefinition,
     ) {
+        super(error);
     }
 
-    validate(
-        errorReporter: (errorMessage: string) => void,
-    ): boolean {
-        let valid = true;
-
+    validate(): void {
         if (this.definition.scripts) {
             for (const scriptPath of this.definition.scripts) {
                 if (!this.filePaths.has(path.normalize(scriptPath))) {
-                    valid = false;
-                    errorReporter(`Script "${scriptPath}" does not exist`);
+                    this.error(`Script "${scriptPath}" does not exist`);
                 }
             }
         }
-
-        return valid;
     }
 }

--- a/lib/validators/unit-type-validator.ts
+++ b/lib/validators/unit-type-validator.ts
@@ -11,26 +11,21 @@ const TYPES = [
 ];
 const TYPES_REGEXP = new RegExp(`^(${TYPES.join('|')})$`, 'i');
 
-export class UnitTypeValidator implements Validator {
+export class UnitTypeValidator extends Validator {
 
     constructor(
+        error: (errorMessage: string) => false,
         private definition: ComponentsDefinition,
     ) {
+        super(error);
     }
 
-    validate(
-        errorReporter: (errorMessage: string) => void,
-    ): boolean {
-        let valid = true;
-
+    validate(): void {
         for (const property of this.definition.componentProperties) {
             if (property.control.type === 'text' && property.control.unit && !TYPES_REGEXP.test(property.control.unit)) {
-                errorReporter(`Property "${property.name}" has unaccaptable unit type "${property.control.unit}", ` +
+                this.error(`Property "${property.name}" has unaccaptable unit type "${property.control.unit}", ` +
                     `only "${TYPES.join(',')}" are allowed`);
-                valid = false;
             }
         }
-
-        return valid;
     }
 }

--- a/lib/validators/validator.ts
+++ b/lib/validators/validator.ts
@@ -1,5 +1,14 @@
-export interface Validator {
-    validate(
-        errorReporter: (errorMessage: string) => void,
-    ) : boolean | Promise<boolean>;
+export abstract class Validator {
+    constructor(
+        protected error: (errorMessage: string) => false,
+    ) {
+
+    }
+
+    /**
+     * To be implemented by validator.
+     * The implementation should call the error method when validation fails.
+     * May be called multiple times.
+     */
+    abstract validate() : void;
 }

--- a/test/validators/autofill-validator.test.ts
+++ b/test/validators/autofill-validator.test.ts
@@ -2,6 +2,7 @@ import { AutofillValidator } from '../../lib/validators/autofill-validator';
 
 describe('AutofillValidator', () => {
     let definition: any;
+    let error: jasmine.Spy;
     let validator: AutofillValidator;
     beforeEach(() => {
         // valid definition (cut)
@@ -43,53 +44,43 @@ describe('AutofillValidator', () => {
                 },
             },
         };
-        validator = new AutofillValidator(definition);
+        error = jasmine.createSpy('error');
+        validator = new AutofillValidator(error, definition);
     });
     describe('validate', () => {
-        let reporter: jasmine.Spy;
-        beforeEach(() => {
-            reporter = jasmine.createSpy('reporter');
-        });
         it('should pass on valid definition', () => {
-            const valid = validator.validate(reporter);
-            expect(valid).toBeTruthy();
-            expect(reporter).not.toHaveBeenCalled();
+            validator.validate();
+            expect(error).not.toHaveBeenCalled();
         });
         it('should not pass if destination directive does not exist', () => {
             delete definition.components.c2.directives.title;
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Component "c2" has incorrect autofill rule "title". This component doesn't have directive "title".`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Component "c2" has incorrect autofill rule "title". This component doesn't have directive "title".`);
         });
         it('should not pass if destination directive is not supported', () => {
             definition.components.c2.directives.title.type = 'image';
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Component "c2" has incorrect autofill rule "title". Supported types of destination directive are "editable", "link" only.`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Component "c2" has incorrect autofill rule "title". Supported types of destination directive are "editable", "link" only.`);
         });
         it('should not pass if source directive does not exist', () => {
             definition.components.c2.component.directiveOptions.title.autofill.source = 'figure2';
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Component "c2" has incorrect autofill rule "title". This component doesn't have directive "figure2".`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Component "c2" has incorrect autofill rule "title". This component doesn't have directive "figure2".`);
         });
         it('should not pass if source directive type is unsupported', () => {
             definition.components.c2.component.directiveOptions.title.autofill.source = 'editable';
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Component \"c2\" has incorrect autofill rule \"title\". This component doesn't have directive \"editable\".`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Component \"c2\" has incorrect autofill rule \"title\". This component doesn't have directive \"editable\".`);
         });
         it('should not pass if source directive is image and metadataField is not set', () => {
             delete definition.components.c2.component.directiveOptions.title.autofill.metadataField;
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Component "c2" has incorrect autofill rule "title". If source directive is image kind then "metadataField" must be set.`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Component "c2" has incorrect autofill rule "title". If source directive is image kind then "metadataField" must be set.`);
         });
         it('should not pass if source and destination directives are the same', () => {
             definition.components.c2.component.directiveOptions.title.autofill.source = 'title';
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Component "c2" has incorrect autofill rule "title". There is no sense to fill directive content from itself.`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Component "c2" has incorrect autofill rule "title". There is no sense to fill directive content from itself.`);
         });
     });
 });

--- a/test/validators/components-validator.test.ts
+++ b/test/validators/components-validator.test.ts
@@ -3,6 +3,7 @@ import { ComponentsValidator } from '../../lib/validators/components-validator';
 
 describe('ComponentsValidator', () => {
     let definition: any;
+    let error: jasmine.Spy;
     let validator: ComponentsValidator;
     let fileList: Set<string>;
     beforeEach(() => {
@@ -32,56 +33,46 @@ describe('ComponentsValidator', () => {
             path.normalize('./styles/design.scss'),
             path.normalize('./styles/design.css'),
         ]);
-        validator = new ComponentsValidator(fileList, definition);
+        error = jasmine.createSpy('error');
+        validator = new ComponentsValidator(error, fileList, definition);
     });
     describe('validate', () => {
-        let reporter: jasmine.Spy;
-        beforeEach(() => {
-            reporter = jasmine.createSpy('reporter');
-        });
         it('should pass on valid definition', () => {
-            const valid = validator.validate(reporter);
-            expect(valid).toBeTruthy();
-            expect(reporter).not.toHaveBeenCalled();
+            validator.validate();
+            expect(error).not.toHaveBeenCalled();
         });
         it('should not pass if the names are not unique', () => {
             definition.components[0].name = 'intro';
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Component "intro" is not unique`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Component "intro" is not unique`);
         });
         it('should not pass if reserved word is used as a name (__internal__)', () => {
             definition.components[0].name = '__internal__bla';
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Component name "__internal__bla" is a reserved word`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Component name "__internal__bla" is a reserved word`);
         });
         it('should not pass if there is no icon file', () => {
             definition.components[1].icon = 'pathU';
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Component "intro" icon missing "pathU"`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Component "intro" icon missing "pathU"`);
         });
         it('should not pass if "design.css" is missing', () => {
             const file = path.normalize('./styles/design.css');
             fileList.delete(file);
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`File "${file}" is missing`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`File "${file}" is missing`);
         });
         it('should not pass if "design.scss" is missing', () => {
             const file = path.normalize('./styles/design.scss');
             fileList.delete(file);
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`File "${file}" is missing`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`File "${file}" is missing`);
         });
         it('should not pass if "_common.scss" is missing', () => {
             const file = path.normalize('./styles/_common.scss');
             fileList.delete(file);
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`File "${file}" is missing`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`File "${file}" is missing`);
         });
     });
 });

--- a/test/validators/conversion-rules-validator.test.ts
+++ b/test/validators/conversion-rules-validator.test.ts
@@ -2,6 +2,7 @@ import { ConversionRulesValidator } from '../../lib/validators/conversion-rules-
 
 describe('ConversionRulesValidator', () => {
     let definition: any;
+    let error: jasmine.Spy;
     let validator: ConversionRulesValidator;
     beforeEach(() => {
         // valid definition (cut)
@@ -36,17 +37,13 @@ describe('ConversionRulesValidator', () => {
                 }
             }
         };
-        validator = new ConversionRulesValidator(definition);
+        error = jasmine.createSpy('error');
+        validator = new ConversionRulesValidator(error, definition);
     });
     describe('validate', () => {
-        let reporter: jasmine.Spy;
-        beforeEach(() => {
-            reporter = jasmine.createSpy('reporter');
-        });
         it('should pass on valid definition', () => {
-            const valid = validator.validate(reporter);
-            expect(valid).toBeTruthy();
-            expect(reporter).not.toHaveBeenCalled();
+            validator.validate();
+            expect(error).not.toHaveBeenCalled();
         });
         it('should pass on valid definition (simple)', () => {
             definition.conversionRules.c1 = {
@@ -57,9 +54,8 @@ describe('ConversionRulesValidator', () => {
                     }
                 }
             };
-            const valid = validator.validate(reporter);
-            expect(valid).toBeTruthy();
-            expect(reporter).not.toHaveBeenCalled();
+            validator.validate();
+            expect(error).not.toHaveBeenCalled();
         });
         it('should pass on valid definition (from-container)', () => {
             definition.conversionRules.c1 = {
@@ -69,9 +65,8 @@ describe('ConversionRulesValidator', () => {
                 }
             };
             definition.components.c1.directives.slide.type = 'slideshow';
-            const valid = validator.validate(reporter);
-            expect(valid).toBeTruthy();
-            expect(reporter).not.toHaveBeenCalled();
+            validator.validate();
+            expect(error).not.toHaveBeenCalled();
         });
         it('should pass on valid definition (to-container)', () => {
             definition.conversionRules.c1 = {
@@ -81,23 +76,20 @@ describe('ConversionRulesValidator', () => {
                 }
             };
             definition.components.c2.directives.figure.type = 'slideshow';
-            const valid = validator.validate(reporter);
-            expect(valid).toBeTruthy();
-            expect(reporter).not.toHaveBeenCalled();
+            validator.validate();
+            expect(error).not.toHaveBeenCalled();
         });
         it('should not pass if source component does not exist', () => {
             definition.conversionRules.u1 = {};
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Conversion rule references to non existing component "u1"`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Conversion rule references to non existing component "u1"`);
         });
         it('should not pass if destination component does not exist', () => {
             definition.conversionRules.c1 = {
                 u2: 'auto'
             };
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Conversion rule references to non existing component "u2"`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Conversion rule references to non existing component "u2"`);
         });
         it('should not pass if source directive does not exist', () => {
             definition.conversionRules.c1 = {
@@ -108,9 +100,8 @@ describe('ConversionRulesValidator', () => {
                     }
                 }
             };
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Conversion rule references to non existing directive "ud1"`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Conversion rule references to non existing directive "ud1"`);
         });
         it('should not pass if destination directive does not exist', () => {
             definition.conversionRules.c1 = {
@@ -121,9 +112,8 @@ describe('ConversionRulesValidator', () => {
                     }
                 }
             };
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Conversion rule references to non existing directive "ud2"`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Conversion rule references to non existing directive "ud2"`);
         });
         it('should not pass if from-container directive does not exist', () => {
             definition.conversionRules.c1 = {
@@ -132,9 +122,8 @@ describe('ConversionRulesValidator', () => {
                     container: 'ud3'
                 }
             };
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Conversion rule references to non existing directive "ud3"`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Conversion rule references to non existing directive "ud3"`);
         });
         it('should not pass if from-container directive is not supported', () => {
             definition.conversionRules.c1 = {
@@ -143,9 +132,8 @@ describe('ConversionRulesValidator', () => {
                     container: 'slide'
                 }
             };
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Conversion rule references to a directive "slide" which must be "slideshow" or "container"`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Conversion rule references to a directive "slide" which must be "slideshow" or "container"`);
         });
         it('should not pass if to-container directive does not exist', () => {
             definition.conversionRules.c1 = {
@@ -154,9 +142,8 @@ describe('ConversionRulesValidator', () => {
                     container: 'ud4'
                 }
             };
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Conversion rule references to non existing directive "ud4"`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Conversion rule references to non existing directive "ud4"`);
         });
         it('should not pass if to-container directive is not supported', () => {
             definition.conversionRules.c1 = {
@@ -165,9 +152,8 @@ describe('ConversionRulesValidator', () => {
                     container: 'figure'
                 }
             };
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Conversion rule references to a directive "figure" which must be "slideshow" or "container"`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Conversion rule references to a directive "figure" which must be "slideshow" or "container"`);
         });
     });
 });

--- a/test/validators/default-component-on-enter-override-validator.test.ts
+++ b/test/validators/default-component-on-enter-override-validator.test.ts
@@ -2,6 +2,7 @@ import { DefaultComponentOnEnterOverrideValidator } from '../../lib/validators/d
 
 describe('DefaultComponentOnEnterOverrideValidator', () => {
     let definition: any;
+    let error: jasmine.Spy;
     let validator: DefaultComponentOnEnterOverrideValidator;
     beforeEach(() => {
         // valid definition (cut)
@@ -20,23 +21,18 @@ describe('DefaultComponentOnEnterOverrideValidator', () => {
                 },
             },
         };
-        validator = new DefaultComponentOnEnterOverrideValidator(definition);
+        error = jasmine.createSpy('error');
+        validator = new DefaultComponentOnEnterOverrideValidator(error, definition);
     });
     describe('validate', () => {
-        let reporter: jasmine.Spy;
-        beforeEach(() => {
-            reporter = jasmine.createSpy('reporter');
-        });
         it('should pass on valid definition', () => {
-            const valid = validator.validate(reporter);
-            expect(valid).toBeTruthy();
-            expect(reporter).not.toHaveBeenCalled();
+            validator.validate();
+            expect(error).not.toHaveBeenCalled();
         });
         it('should not pass if it points to non existing component', () => {
             definition.components.text.component.defaultComponentOnEnter = 'body2';
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Property "defaultComponentOnEnter" of "text" points to non existing component "body2"`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Property "defaultComponentOnEnter" of "text" points to non existing component "body2"`);
         });
     });
 });

--- a/test/validators/default-component-on-enter-validator.test.ts
+++ b/test/validators/default-component-on-enter-validator.test.ts
@@ -2,6 +2,7 @@ import { DefaultComponentOnEnterValidator } from '../../lib/validators/default-c
 
 describe('DefaultComponentOnEnterValidator', () => {
     let definition: any;
+    let error: jasmine.Spy;
     let validator: DefaultComponentOnEnterValidator;
     beforeEach(() => {
         // valid definition (cut)
@@ -22,23 +23,18 @@ describe('DefaultComponentOnEnterValidator', () => {
             },
             defaultComponentOnEnter: 'text',
         };
-        validator = new DefaultComponentOnEnterValidator(definition);
+        error = jasmine.createSpy('error');
+        validator = new DefaultComponentOnEnterValidator(error, definition);
     });
     describe('validate', () => {
-        let reporter: jasmine.Spy;
-        beforeEach(() => {
-            reporter = jasmine.createSpy('reporter');
-        });
         it('should pass on valid definition', () => {
-            const valid = validator.validate(reporter);
-            expect(valid).toBeTruthy();
-            expect(reporter).not.toHaveBeenCalled();
+            validator.validate();
+            expect(error).not.toHaveBeenCalled();
         });
         it('should not pass if it points to non existing component', () => {
             definition.defaultComponentOnEnter = 'body';
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Property "defaultComponentOnEnter" points to non existing component "body"`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Property "defaultComponentOnEnter" points to non existing component "body"`);
         });
     });
 });

--- a/test/validators/default-values-validator.test.ts
+++ b/test/validators/default-values-validator.test.ts
@@ -2,8 +2,8 @@ import { DefaultValuesValidator } from '../../lib/validators/default-values-vali
 
 describe('DefaultValuesValidator', () => {
     let definition: any;
+    let error: jasmine.Spy;
     let validator: DefaultValuesValidator;
-    let reporter: jasmine.Spy;
 
     beforeEach(() => {
         // valid definition (cut)
@@ -17,15 +17,14 @@ describe('DefaultValuesValidator', () => {
                 },
             },
         };
-        reporter = jasmine.createSpy('reporter');
+        error = jasmine.createSpy('error');
     });
     describe('validate', () => {
         it('should pass validation if property has no defaultValue set', () => {
-            validator = new DefaultValuesValidator(definition);
-            const valid = validator.validate(reporter);
+            validator = new DefaultValuesValidator(error, definition);
+            validator.validate();
 
-            expect(reporter).not.toHaveBeenCalled();
-            expect(valid).toBe(true);
+            expect(error).not.toHaveBeenCalled();
         });
 
         ['styles', 'inlineStyles', 'data'].forEach((dataType) => {
@@ -37,11 +36,10 @@ describe('DefaultValuesValidator', () => {
                     control: { type: 'text' },
                 });
 
-                validator = new DefaultValuesValidator(definition);
-                const valid = validator.validate(reporter);
+                validator = new DefaultValuesValidator(error, definition);
+                validator.validate();
 
-                expect(reporter).not.toHaveBeenCalled();
-                expect(valid).toBe(true);
+                expect(error).not.toHaveBeenCalled();
             });
         });
 
@@ -53,12 +51,11 @@ describe('DefaultValuesValidator', () => {
                 control: { type: 'text' },
             });
 
-            validator = new DefaultValuesValidator(definition);
-            const valid = validator.validate(reporter);
+            validator = new DefaultValuesValidator(error, definition);
+            validator.validate();
 
-            expect(reporter).toHaveBeenCalledWith(
+            expect(error).toHaveBeenCalledWith(
                 'Property propertyName has a default value for an unsupported data type doc-editable');
-            expect(valid).toBe(false);
         });
 
         it('should not pass with unsupported control type', () => {
@@ -71,12 +68,11 @@ describe('DefaultValuesValidator', () => {
                 },
             });
 
-            validator = new DefaultValuesValidator(definition);
-            const valid = validator.validate(reporter);
+            validator = new DefaultValuesValidator(error, definition);
+            validator.validate();
 
-            expect(reporter).toHaveBeenCalledWith(
+            expect(error).toHaveBeenCalledWith(
                 'Property propertyName has a default value used with an unsupported control type unsupported');
-            expect(valid).toBe(false);
         });
 
         it('should pass with control type select and defaultValue being present in options', () => {
@@ -93,11 +89,10 @@ describe('DefaultValuesValidator', () => {
                 },
             });
 
-            validator = new DefaultValuesValidator(definition);
-            const valid = validator.validate(reporter);
+            validator = new DefaultValuesValidator(error, definition);
+            validator.validate();
 
-            expect(reporter).not.toHaveBeenCalled();
-            expect(valid).toBe(true);
+            expect(error).not.toHaveBeenCalled();
         });
 
         it('should not pass with control type select and defaultValue not being present in options', () => {
@@ -114,12 +109,11 @@ describe('DefaultValuesValidator', () => {
                 },
             });
 
-            validator = new DefaultValuesValidator(definition);
-            const valid = validator.validate(reporter);
+            validator = new DefaultValuesValidator(error, definition);
+            validator.validate();
 
-            expect(reporter).toHaveBeenCalledWith(
+            expect(error).toHaveBeenCalledWith(
                 'Property propertyName defaultValue has no matching entry in select options');
-            expect(valid).toBe(false);
         });
 
         it('should pass with control type radio and defaultValue being present in options', () => {
@@ -136,11 +130,10 @@ describe('DefaultValuesValidator', () => {
                 },
             });
 
-            validator = new DefaultValuesValidator(definition);
-            const valid = validator.validate(reporter);
+            validator = new DefaultValuesValidator(error, definition);
+            validator.validate();
 
-            expect(reporter).not.toHaveBeenCalled();
-            expect(valid).toBe(true);
+            expect(error).not.toHaveBeenCalled();
         });
 
         it('should not pass with control type radio and defaultValue not being present in options', () => {
@@ -157,12 +150,11 @@ describe('DefaultValuesValidator', () => {
                 },
             });
 
-            validator = new DefaultValuesValidator(definition);
-            const valid = validator.validate(reporter);
+            validator = new DefaultValuesValidator(error, definition);
+            validator.validate();
 
-            expect(reporter).toHaveBeenCalledWith(
+            expect(error).toHaveBeenCalledWith(
                 'Property propertyName defaultValue has no matching entry in radio options');
-            expect(valid).toBe(false);
         });
 
         it('should pass with control type checkbox and defaultValue being the checked value', () => {
@@ -176,11 +168,10 @@ describe('DefaultValuesValidator', () => {
                 },
             });
 
-            validator = new DefaultValuesValidator(definition);
-            const valid = validator.validate(reporter);
+            validator = new DefaultValuesValidator(error, definition);
+            validator.validate();
 
-            expect(reporter).not.toHaveBeenCalled();
-            expect(valid).toBe(true);
+            expect(error).not.toHaveBeenCalled();
         });
 
         it('should pass with control type checkbox and defaultValue being the checked value', () => {
@@ -194,12 +185,11 @@ describe('DefaultValuesValidator', () => {
                 },
             });
 
-            validator = new DefaultValuesValidator(definition);
-            const valid = validator.validate(reporter);
+            validator = new DefaultValuesValidator(error, definition);
+            validator.validate();
 
-            expect(reporter).toHaveBeenCalledWith(
+            expect(error).toHaveBeenCalledWith(
                 'Property propertyName defaultValue does not match checkbox value');
-            expect(valid).toBe(false);
         });
     });
 });

--- a/test/validators/directive-properties-validator.test.ts
+++ b/test/validators/directive-properties-validator.test.ts
@@ -2,6 +2,7 @@ import { DirectivePropertiesValidator } from '../../lib/validators/directive-pro
 
 describe('DirectivePropertiesValidator', () => {
     let definition: any;
+    let error: jasmine.Spy;
     let validator: DirectivePropertiesValidator;
     beforeEach(() => {
         // valid definition (cut)
@@ -38,35 +39,28 @@ describe('DirectivePropertiesValidator', () => {
                 }
             }
         };
-        validator = new DirectivePropertiesValidator(definition);
+        error = jasmine.createSpy('error');
+        validator = new DirectivePropertiesValidator(error, definition);
     });
     describe('validate', () => {
-        let reporter: jasmine.Spy;
-        beforeEach(() => {
-            reporter = jasmine.createSpy('reporter');
-        });
         it('should pass on valid definition', () => {
-            const valid = validator.validate(reporter);
-            expect(valid).toBeTruthy();
-            expect(reporter).not.toHaveBeenCalled();
+            validator.validate();
+            expect(error).not.toHaveBeenCalled();
         });
         it('should pass on valid definition (other control type)', () => {
             definition.components.picture.properties[0].control.type = 'interactive';
-            const valid = validator.validate(reporter);
-            expect(valid).toBeTruthy();
-            expect(reporter).not.toHaveBeenCalled();
+            validator.validate();
+            expect(error).not.toHaveBeenCalled();
         });
         it('should not pass if directive key is not set', () => {
             delete definition.components.picture.properties[0].directiveKey;
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Property "test" of component "picture" must reference to a directive`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Property "test" of component "picture" must reference to a directive`);
         });
         it('should not pass if directive key is not set for directive dataType', () => {
             delete definition.components.picture.properties[1].directiveKey;
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Property "test" of component "picture" must reference to a directive because its dataType is a directive type`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Property "test" of component "picture" must reference to a directive because its dataType is a directive type`);
         });
     });
 });

--- a/test/validators/disable-fullscreen-checkbox-validator.test.ts
+++ b/test/validators/disable-fullscreen-checkbox-validator.test.ts
@@ -2,6 +2,7 @@ import { DisableFullscreenCheckboxValidator } from '../../lib/validators/disable
 
 describe('DisableFullscreenCheckboxValidator', () => {
     let definition: any;
+    let error: jasmine.Spy;
     let validator: DisableFullscreenCheckboxValidator;
     beforeEach(() => {
         // valid definition (cut)
@@ -20,23 +21,18 @@ describe('DisableFullscreenCheckboxValidator', () => {
                 dataType: 'data'
             }]
         };
-        validator = new DisableFullscreenCheckboxValidator(definition);
+        error = jasmine.createSpy('error');
+        validator = new DisableFullscreenCheckboxValidator(error, definition);
     });
     describe('validate', () => {
-        let reporter: jasmine.Spy;
-        beforeEach(() => {
-            reporter = jasmine.createSpy('reporter');
-        });
         it('should pass on valid definition', () => {
-            const valid = validator.validate(reporter);
-            expect(valid).toBeTruthy();
-            expect(reporter).not.toHaveBeenCalled();
+            validator.validate();
+            expect(error).not.toHaveBeenCalled();
         });
         it('should not pass if dataType is not "styles"', () => {
             definition.componentProperties[0].dataType = 'data';
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Property "p1" uses "disable-fullscreen-checkbox" control type which is allowed to use with dataType="styles" only`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Property "p1" uses "disable-fullscreen-checkbox" control type which is allowed to use with dataType="styles" only`);
         });
     });
 });

--- a/test/validators/doc-container-groups-validator.test.ts
+++ b/test/validators/doc-container-groups-validator.test.ts
@@ -2,6 +2,7 @@ import { DocContainerGroupsValidator } from '../../lib/validators/doc-container-
 
 describe('DocContainerGroupsValidator', () => {
     let definition: any;
+    let error: jasmine.Spy;
     let validator: DocContainerGroupsValidator;
     beforeEach(() => {
         // valid definition (cut)
@@ -35,55 +36,46 @@ describe('DocContainerGroupsValidator', () => {
                 },
             },
         };
-
+        error = jasmine.createSpy('error');
     });
     describe('validate', () => {
-        let reporter: jasmine.Spy;
-        beforeEach(() => {
-            reporter = jasmine.createSpy('reporter');
-        });
-
         it('should validate a correct definition', () => {
-            validator = new DocContainerGroupsValidator(definition);
+            validator = new DocContainerGroupsValidator(error, definition);
 
-            const valid = validator.validate(reporter);
+            validator.validate();
 
-            expect(reporter).not.toHaveBeenCalled();
-            expect(valid).toBeTruthy();
+            expect(error).not.toHaveBeenCalled();
         });
 
         it('should fail validation for invalid directive', () => {
             delete definition.components.c1.directives.main;
 
-            validator = new DocContainerGroupsValidator(definition);
+            validator = new DocContainerGroupsValidator(error, definition);
 
-            const valid = validator.validate(reporter);
+            validator.validate();
 
-            expect(reporter).toHaveBeenCalledWith(`Component \"c1\" has a group for invalid directive \"main\"`);
-            expect(valid).toBeFalsy();
+            expect(error).toHaveBeenCalledWith(`Component \"c1\" has a group for invalid directive \"main\"`);
         });
 
         it('should fail validation for invalid directive type', () => {
             definition.components.c1.directives.main.type = 'editable';
 
-            validator = new DocContainerGroupsValidator(definition);
+            validator = new DocContainerGroupsValidator(error, definition);
 
-            const valid = validator.validate(reporter);
+            validator.validate();
 
-            expect(reporter).toHaveBeenCalledWith(`Component \"c1\" has a group for directive \"main\" with incompatible type \"editable\". Only type \"container\" is allowed.`);
-            expect(valid).toBeFalsy();
+            expect(error).toHaveBeenCalledWith(`Component \"c1\" has a group for directive \"main\" with incompatible type \"editable\". Only type \"container\" is allowed.`);
         });
 
         it('should fail validation if component misses', () => {
             // Remove the component
             delete definition.components.picture;
 
-            validator = new DocContainerGroupsValidator(definition);
+            validator = new DocContainerGroupsValidator(error, definition);
 
-            const valid = validator.validate(reporter);
+            validator.validate();
 
-            expect(reporter).toHaveBeenCalledWith(`Component \"picture\" of group \"g1\" does not exist`);
-            expect(valid).toBeFalsy();
+            expect(error).toHaveBeenCalledWith(`Component \"picture\" of group \"g1\" does not exist`);
         });
     });
 });

--- a/test/validators/doc-container-validator.test.ts
+++ b/test/validators/doc-container-validator.test.ts
@@ -2,6 +2,7 @@ import { DocContainerValidator } from '../../lib/validators/doc-container-valida
 
 describe('DocContainerValidator', () => {
     let definition: any;
+    let error: jasmine.Spy;
     let validator: DocContainerValidator;
     beforeEach(() => {
         // valid definition (cut)
@@ -21,17 +22,13 @@ describe('DocContainerValidator', () => {
                 }
             }
         };
-        validator = new DocContainerValidator(definition);
+        error = jasmine.createSpy('error');
+        validator = new DocContainerValidator(error, definition);
     });
     describe('validate', () => {
-        let reporter: jasmine.Spy;
-        beforeEach(() => {
-            reporter = jasmine.createSpy('reporter');
-        });
         it('should pass on valid definition', () => {
-            const valid = validator.validate(reporter);
-            expect(valid).toBeTruthy();
-            expect(reporter).not.toHaveBeenCalled();
+            validator.validate();
+            expect(error).not.toHaveBeenCalled();
         });
         it('should pass if there is only one container directive and another type of directive', () => {
             definition.components.container.directives.d1.type = 'editable';
@@ -39,27 +36,24 @@ describe('DocContainerValidator', () => {
                 'type': 'editable',
                 'tag': 'div'
             };
-            const valid = validator.validate(reporter);
-            expect(valid).toBeTruthy();
-            expect(reporter).not.toHaveBeenCalled();
+            validator.validate();
+            expect(error).not.toHaveBeenCalled();
         });
         it('should pass if there is a container directive and another type of directive', () => {
             definition.components.container.directives.d2 = {
                 'type': 'editable',
                 'tag': 'div'
             };
-            const valid = validator.validate(reporter);
-            expect(valid).toBeTruthy();
-            expect(reporter).not.toHaveBeenCalled();
+            validator.validate();
+            expect(error).not.toHaveBeenCalled();
         });
         it('should not pass if there are a container and slideshow directive', () => {
             definition.components.container.directives.d2 = {
                 'type': 'slideshow',
                 'tag': 'div'
             };
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Component "container" contains both a container and slideshow directive,` +
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Component "container" contains both a container and slideshow directive,` +
             `but can only contain one of those directive types`);
         });
         it('should not pass if there are multiple container directives', () => {
@@ -67,9 +61,8 @@ describe('DocContainerValidator', () => {
                 'type': 'container',
                 'tag': 'div'
             };
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Component "container" can only have one container directive`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Component "container" can only have one container directive`);
         });
     });
 });

--- a/test/validators/doc-media-validator.test.ts
+++ b/test/validators/doc-media-validator.test.ts
@@ -2,6 +2,7 @@ import { DocMediaValidator } from '../../lib/validators/doc-media-validator';
 
 describe('DocMediaValidator', () => {
     let definition: any;
+    let error: jasmine.Spy;
     let validator: DocMediaValidator;
 
     beforeEach(() => {
@@ -43,17 +44,13 @@ describe('DocMediaValidator', () => {
                 }
             }
         };
-        validator = new DocMediaValidator(definition);
+        error = jasmine.createSpy('error');
+        validator = new DocMediaValidator(error, definition);
     });
     describe('validate', () => {
-        let reporter: jasmine.Spy;
-        beforeEach(() => {
-            reporter = jasmine.createSpy('reporter');
-        });
         it('should pass on a valid definition', () => {
-            const valid = validator.validate(reporter);
-            expect(reporter).not.toHaveBeenCalled();
-            expect(valid).toBeTruthy();
+            validator.validate();
+            expect(error).not.toHaveBeenCalled();
         });
         it('should pass with one media directives and other directive types', () => {
             definition.components.socialmedia.directives.d2 = {
@@ -64,18 +61,16 @@ describe('DocMediaValidator', () => {
                 type: 'link',
                 tag: 'a'
             };
-            const valid = validator.validate(reporter);
-            expect(reporter).not.toHaveBeenCalled();
-            expect(valid).toBeTruthy();
+            validator.validate();
+            expect(error).not.toHaveBeenCalled();
         });
         it('should not pass with multiple media type directives', () => {
             definition.components.socialmedia.directives.d2 = {
                 type: 'media',
                 tag: 'div'
             };
-            const valid = validator.validate(reporter);
-            expect(reporter).toHaveBeenCalledWith(`A component can have only one "doc-media" directive in the HTML definition`);
-            expect(valid).toBeFalsy();
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`A component can have only one "doc-media" directive in the HTML definition`);
         });
         it('should fail if a component property with a media-properties control type is not applied to a media directive', () => {
             definition.components.wrongdirectivekey = {
@@ -103,9 +98,8 @@ describe('DocMediaValidator', () => {
                     }
                 ]
             };
-            const valid = validator.validate(reporter);
-            expect(reporter).toHaveBeenCalledWith(`Control type "media-properties" is only applicable to "doc-media" directives`);
-            expect(valid).toBeFalsy();
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Control type "media-properties" is only applicable to "doc-media" directives`);
         });
         it('should fail in case a component does not have a doc-media directive, but has a media-properties control type', () => {
             definition.components.nomediaproperties = {
@@ -129,9 +123,8 @@ describe('DocMediaValidator', () => {
                     }
                 ]
             };
-            const valid = validator.validate(reporter);
-            expect(reporter).toHaveBeenCalledWith(`Only components with a doc-media directive can have a "media-properties" control type`);
-            expect(valid).toBeFalsy();
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Only components with a doc-media directive can have a "media-properties" control type`);
         });
         it('should fail in case a "media-properties" property does not have a directive key', () => {
             definition.components.nodirectivekey = {
@@ -154,9 +147,8 @@ describe('DocMediaValidator', () => {
                     }
                 ]
             };
-            const valid = validator.validate(reporter);
-            expect(reporter).toHaveBeenCalledWith(`The directive key is required for properties of type "media-properties"`);
-            expect(valid).toBeFalsy();
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`The directive key is required for properties of type "media-properties"`);
         });
     });
 });

--- a/test/validators/doc-slideshow-validator.test.ts
+++ b/test/validators/doc-slideshow-validator.test.ts
@@ -2,6 +2,7 @@ import { DocSlideshowValidator } from '../../lib/validators/doc-slideshow-valida
 
 describe('DocSlideshowValidator', () => {
     let definition: any;
+    let error: jasmine.Spy;
     let validator: DocSlideshowValidator;
     beforeEach(() => {
         // valid definition (cut)
@@ -21,35 +22,29 @@ describe('DocSlideshowValidator', () => {
                 }
             }
         };
-        validator = new DocSlideshowValidator(definition);
+        error = jasmine.createSpy('error');
+        validator = new DocSlideshowValidator(error, definition);
     });
     describe('validate', () => {
-        let reporter: jasmine.Spy;
-        beforeEach(() => {
-            reporter = jasmine.createSpy('reporter');
-        });
         it('should pass on valid definition', () => {
-            const valid = validator.validate(reporter);
-            expect(valid).toBeTruthy();
-            expect(reporter).not.toHaveBeenCalled();
+            validator.validate();
+            expect(error).not.toHaveBeenCalled();
         });
         it('should pass if there are a slideshow directive and others', () => {
             definition.components.slides.directives.d2 = {
                 'type': 'editable',
                 'tag': 'div'
             };
-            const valid = validator.validate(reporter);
-            expect(valid).toBeTruthy();
-            expect(reporter).not.toHaveBeenCalled();
+            validator.validate();
+            expect(error).not.toHaveBeenCalled();
         });
         it('should not pass if there are a slideshow directive and other one', () => {
             definition.components.slides.directives.d2 = {
                 'type': 'slideshow',
                 'tag': 'div'
             };
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Component "slides" contains more then one slideshow directive, only one is allowed per component`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Component "slides" contains more then one slideshow directive, only one is allowed per component`);
         });
     });
 });

--- a/test/validators/drop-capital-validator.test.ts
+++ b/test/validators/drop-capital-validator.test.ts
@@ -3,6 +3,7 @@ import { DropCapitalValidator } from '../../lib/validators/drop-capital-validato
 describe('DropCapitalValidator', () => {
     let definition: any;
     let parsedDefinition: any;
+    let error: jasmine.Spy;
     let validator: DropCapitalValidator;
     beforeEach(() => {
         // valid definition (cut)
@@ -38,23 +39,18 @@ describe('DropCapitalValidator', () => {
                 },
             },
         };
-        validator = new DropCapitalValidator(definition, parsedDefinition);
+        error = jasmine.createSpy('error');
+        validator = new DropCapitalValidator(error, definition, parsedDefinition);
     });
     describe('validate', () => {
-        let reporter: jasmine.Spy;
-        beforeEach(() => {
-            reporter = jasmine.createSpy('reporter');
-        });
         it('should pass on valid definition', () => {
-            const valid = validator.validate(reporter);
-            expect(valid).toBeTruthy();
-            expect(reporter).not.toHaveBeenCalled();
+            validator.validate();
+            expect(error).not.toHaveBeenCalled();
         });
         it('should not pass if dataType is not "data"', () => {
             definition.componentProperties[0].dataType = 'styles';
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Property "p1" uses "drop-capital" control type which is allowed to use with dataType="data" only`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Property "p1" uses "drop-capital" control type which is allowed to use with dataType="data" only`);
         });
         it('should not pass if there is a component which uses "drop-capital" property more then one time', () => {
             parsedDefinition.components.c1.properties.push({
@@ -63,9 +59,8 @@ describe('DropCapitalValidator', () => {
                     type: 'drop-capital',
                 },
             });
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Component "c1" uses properties with "drop-capital" control type more that one time`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Component "c1" uses properties with "drop-capital" control type more that one time`);
         });
     });
 });

--- a/test/validators/fitting-validator.test.ts
+++ b/test/validators/fitting-validator.test.ts
@@ -2,6 +2,7 @@ import { FittingValidator } from '../../lib/validators/fitting-validator';
 
 describe('FittingValidator', () => {
     let parsedDefinition: any;
+    let error: jasmine.Spy;
     let validator: FittingValidator;
     beforeEach(() => {
         // valid definition (cut)
@@ -28,17 +29,13 @@ describe('FittingValidator', () => {
                 },
             },
         };
-        validator = new FittingValidator(parsedDefinition);
+        error = jasmine.createSpy('error');
+        validator = new FittingValidator(error, parsedDefinition);
     });
     describe('validate', () => {
-        let reporter: jasmine.Spy;
-        beforeEach(() => {
-            reporter = jasmine.createSpy('reporter');
-        });
         it('should pass on valid definition', () => {
-            const valid = validator.validate(reporter);
-            expect(valid).toBeTruthy();
-            expect(reporter).not.toHaveBeenCalled();
+            validator.validate();
+            expect(error).not.toHaveBeenCalled();
         });
         it('should not pass if there is a component which uses "fitting" property more then one time', () => {
             parsedDefinition.components.c1.properties.push({
@@ -47,9 +44,8 @@ describe('FittingValidator', () => {
                     type: 'fitting',
                 },
             });
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Component "c1" uses properties with "fitting" control type more that one time`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Component "c1" uses properties with "fitting" control type more that one time`);
         });
     });
 });

--- a/test/validators/focuspoint-validator.test.ts
+++ b/test/validators/focuspoint-validator.test.ts
@@ -2,6 +2,7 @@ import { FocuspointValidator } from '../../lib/validators/focuspoint-validator';
 
 describe('FocuspointValidator', () => {
     let definition: any;
+    let error: jasmine.Spy;
     let validator: FocuspointValidator;
     beforeEach(() => {
         // valid definition (cut)
@@ -30,30 +31,24 @@ describe('FocuspointValidator', () => {
                 }
             }
         };
-        validator = new FocuspointValidator(definition);
+        error = jasmine.createSpy('error');
+        validator = new FocuspointValidator(error, definition);
     });
     describe('validate', () => {
-        let reporter: jasmine.Spy;
-        beforeEach(() => {
-            reporter = jasmine.createSpy('reporter');
-        });
         it('should pass on valid definition', () => {
-            const valid = validator.validate(reporter);
-            expect(valid).toBeTruthy();
-            expect(reporter).not.toHaveBeenCalled();
+            validator.validate();
+            expect(error).not.toHaveBeenCalled();
         });
         it('should pass if directive is applied to <img> tag but "focuspoint" is not set', () => {
             definition.components.picture.directives.slide.tag = 'img';
             delete definition.components.picture.properties[0].control.focuspoint;
-            const valid = validator.validate(reporter);
-            expect(valid).toBeTruthy();
-            expect(reporter).not.toHaveBeenCalled();
+            validator.validate();
+            expect(error).not.toHaveBeenCalled();
         });
         it('should not pass if directive is applied to <img> tag', () => {
             definition.components.picture.directives.slide.tag = 'img';
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Property "test" of component "picture" uses "focuspoint" feature on <img> html tag, which is not supported, "focuspoint" can be applied to other html tags, whereimage is a background`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Property "test" of component "picture" uses "focuspoint" feature on <img> html tag, which is not supported, "focuspoint" can be applied to other html tags, whereimage is a background`);
         });
     });
 });

--- a/test/validators/groups-validator.test.ts
+++ b/test/validators/groups-validator.test.ts
@@ -1,7 +1,7 @@
 import { GroupsValidator } from '../../lib/validators/groups-validator';
 
 describe('GroupsValidator', () => {
-    let definition: any;
+    let error: jasmine.Spy, definition: any;
     let validator: GroupsValidator;
     beforeEach(() => {
         // valid definition (cut)
@@ -38,35 +38,29 @@ describe('GroupsValidator', () => {
                 },
             ],
         };
-        validator = new GroupsValidator(definition);
+        error = jasmine.createSpy('error');
+        validator = new GroupsValidator(error, definition);
     });
     describe('validate', () => {
-        let reporter: jasmine.Spy;
-        beforeEach(() => {
-            reporter = jasmine.createSpy('reporter');
-        });
         it('should pass on valid definition', () => {
-            const valid = validator.validate(reporter);
-            expect(valid).toBeTruthy();
-            expect(reporter).not.toHaveBeenCalled();
+            validator.validate();
+            expect(error).not.toHaveBeenCalled();
         });
         it('should not pass if a group name is not unique', () => {
             definition.groups.push({
                 name: 'g1',
                 components: ['picture']
             });
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Component group "g1" is not unique`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Component group "g1" is not unique`);
         });
         it('should not pass if a group contains non existing component', () => {
             definition.groups.push({
                 name: 'g2',
                 components: ['none']
             });
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Component "none" of group "g2" does not exist`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Component "none" of group "g2" does not exist`);
         });
     });
 });

--- a/test/validators/icons-validator.test.ts
+++ b/test/validators/icons-validator.test.ts
@@ -3,6 +3,7 @@ import { readFile } from 'fs';
 
 describe('IconsValidator', () => {
     let definition: any;
+    let error: jasmine.Spy;
     let validator: IconsValidator;
     let getFileContent;
     beforeEach(() => {
@@ -30,44 +31,37 @@ describe('IconsValidator', () => {
                 });
             });
         });
-        validator = new IconsValidator(definition, getFileContent);
+        error = jasmine.createSpy('error');
+        validator = new IconsValidator(error, definition, getFileContent);
     });
     describe('validate', () => {
-        let reporter: jasmine.Spy;
-        beforeEach(() => {
-            reporter = jasmine.createSpy('reporter');
-        });
         it('should pass on valid definition', async () => {
-            const valid = await validator.validate(reporter);
-            expect(reporter).not.toHaveBeenCalled();
-            expect(valid).toBeTruthy();
+            await validator.validate();
+            expect(error).not.toHaveBeenCalled();
         });
         it('should pass with capitalized file extensions', async () => {
             definition.components.push({
                 name: 'capitals',
                 icon: 'component.SVG'
             });
-            const valid = await validator.validate(reporter);
-            expect(reporter).not.toHaveBeenCalled();
-            expect(valid).toBeTruthy();
+            await validator.validate();
+            expect(error).not.toHaveBeenCalled();
         });
         it('should fail for a non-supported file extension', async () => {
             definition.components.push({
                 name: 'unsupported',
                 icon: 'unsupported.txt'
             });
-            const valid = await validator.validate(reporter);
-            expect(reporter).toHaveBeenCalledWith(`Icons are only supported in SVG or transparent PNG format`);
-            expect(valid).toBeFalsy();
+            await validator.validate();
+            expect(error).toHaveBeenCalledWith(`Icons are only supported in SVG or transparent PNG format`);
         });
         it('should fail for non-transparent PNG icons', async () => {
             definition.components.push({
                 name: 'opaque',
                 icon: './test/resources/minimal-sample/icons/opaque.png'
             });
-            const valid = await validator.validate(reporter);
-            expect(reporter).toHaveBeenCalledWith(`PNG icons are only supported when they are transparent`);
-            expect(valid).toBeFalsy();
+            await validator.validate();
+            expect(error).toHaveBeenCalledWith(`PNG icons are only supported when they are transparent`);
         });
     });
 });

--- a/test/validators/image-editor-validator.test.ts
+++ b/test/validators/image-editor-validator.test.ts
@@ -2,6 +2,7 @@ import { ImageEditorValidator } from '../../lib/validators/image-editor-validato
 
 describe('ImageEditorValidator', () => {
     let definition: any;
+    let error: jasmine.Spy;
     let validator: ImageEditorValidator;
     beforeEach(() => {
         // valid definition (cut)
@@ -20,23 +21,18 @@ describe('ImageEditorValidator', () => {
                 dataType: 'data'
             }]
         };
-        validator = new ImageEditorValidator(definition);
+        error = jasmine.createSpy('error');
+        validator = new ImageEditorValidator(error, definition);
     });
     describe('validate', () => {
-        let reporter: jasmine.Spy;
-        beforeEach(() => {
-            reporter = jasmine.createSpy('reporter');
-        });
         it('should pass on valid definition', () => {
-            const valid = validator.validate(reporter);
-            expect(valid).toBeTruthy();
-            expect(reporter).not.toHaveBeenCalled();
+            validator.validate();
+            expect(error).not.toHaveBeenCalled();
         });
         it('should not pass if dataType is not "doc-image"', () => {
             definition.componentProperties[0].dataType = 'data';
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Property "p1" uses "image-editor" control type which is allowed to use with dataType="doc-image" only`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Property "p1" uses "image-editor" control type which is allowed to use with dataType="doc-image" only`);
         });
     });
 });

--- a/test/validators/interactive-validator.test.ts
+++ b/test/validators/interactive-validator.test.ts
@@ -2,6 +2,7 @@ import { InteractiveValidator } from '../../lib/validators/interactive-validator
 
 describe('InteractiveValidator', () => {
     let definition: any;
+    let error: jasmine.Spy;
     let validator: InteractiveValidator;
     beforeEach(() => {
         // valid definition (cut)
@@ -20,23 +21,18 @@ describe('InteractiveValidator', () => {
                 dataType: 'data'
             }]
         };
-        validator = new InteractiveValidator(definition);
+        error = jasmine.createSpy('error');
+        validator = new InteractiveValidator(error, definition);
     });
     describe('validate', () => {
-        let reporter: jasmine.Spy;
-        beforeEach(() => {
-            reporter = jasmine.createSpy('reporter');
-        });
         it('should pass on valid definition', () => {
-            const valid = validator.validate(reporter);
-            expect(valid).toBeTruthy();
-            expect(reporter).not.toHaveBeenCalled();
+            validator.validate();
+            expect(error).not.toHaveBeenCalled();
         });
         it('should not pass if dataType is not "interactive"', () => {
             definition.componentProperties[0].dataType = 'data';
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Property "p1" uses "interactive" control type which is allowed to use with dataType="doc-interactive" only`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Property "p1" uses "interactive" control type which is allowed to use with dataType="doc-interactive" only`);
         });
     });
 });

--- a/test/validators/properties-validator.test.ts
+++ b/test/validators/properties-validator.test.ts
@@ -2,6 +2,7 @@ import { PropertiesValidator } from '../../lib/validators/properties-validator';
 
 describe('PropertiesValidator', () => {
     let definition: any;
+    let error: jasmine.Spy;
     let validator: PropertiesValidator;
     let fileList: Set<string>;
     beforeEach(() => {
@@ -41,35 +42,28 @@ describe('PropertiesValidator', () => {
             'path4',
             'path5',
         ]);
-        validator = new PropertiesValidator(fileList, definition);
+        error = jasmine.createSpy('error');
+        validator = new PropertiesValidator(error, fileList, definition);
     });
     describe('validate', () => {
-        let reporter: jasmine.Spy;
-        beforeEach(() => {
-            reporter = jasmine.createSpy('reporter');
-        });
         it('should pass on valid definition', () => {
-            const valid = validator.validate(reporter);
-            expect(valid).toBeTruthy();
-            expect(reporter).not.toHaveBeenCalled();
+            validator.validate();
+            expect(error).not.toHaveBeenCalled();
         });
         it('should not pass if the names are not unique', () => {
             definition.componentProperties[0].name = 'p2';
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Component property "p2" is not unique`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Component property "p2" is not unique`);
         });
         it('should not pass if reserved word is used as a name', () => {
             definition.componentProperties[0].name = 'parallax';
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Component property name "parallax" is a reserved word`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Component property name "parallax" is a reserved word`);
         });
         it('should not pass if there is no icon file', () => {
             definition.componentProperties[1].control.options[0].icon = 'pathU';
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Component properties "p2" icon missing "pathU"`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Component properties "p2" icon missing "pathU"`);
         });
     });
 });

--- a/test/validators/restrict-children-validator.test.ts
+++ b/test/validators/restrict-children-validator.test.ts
@@ -2,7 +2,8 @@ import { RestrictChildrenValidator } from '../../lib/validators/restrict-childre
 
 describe('RestrictChildrenValidator', () => {
     let definition: any;
-    let validator: any;
+    let error: jasmine.Spy;
+    let validator: RestrictChildrenValidator;
     beforeEach(() => {
         // valid definition (cut)
         definition = {
@@ -54,53 +55,43 @@ describe('RestrictChildrenValidator', () => {
                 }
             }
         };
-        validator = new RestrictChildrenValidator(definition);
+        error = jasmine.createSpy('error');
+        validator = new RestrictChildrenValidator(error, definition);
     });
     describe('validate', () => {
-        let reporter: jasmine.Spy;
-        beforeEach(() => {
-            reporter = jasmine.createSpy('reporter');
-        });
         it('should pass on valid definition', () => {
-            const valid = validator.validate(reporter);
-            expect(valid).toBeTruthy();
-            expect(reporter).not.toHaveBeenCalled();
+            validator.validate();
+            expect(error).not.toHaveBeenCalled();
         });
         it('should pass on valid definition with additional withContent property', () => {
             definition.components.slider.component.restrictChildren.body.withContent = 'text';
-            const valid = validator.validate(reporter);
-            expect(valid).toBeTruthy();
-            expect(reporter).not.toHaveBeenCalled();
+            validator.validate();
+            expect(error).not.toHaveBeenCalled();
         });
         it('should not pass if there is not restrictChildren property in slideshow component', () => {
             delete definition.components.slider.component.restrictChildren;
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Component property "restrictChildren" must be defined in component "slider" because the component contains a slideshow directive`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Component property "restrictChildren" must be defined in component "slider" because the component contains a slideshow directive`);
         });
         it('should not pass if restrictChildren property additional withContent property point to wrong directive', () => {
             definition.components.slider.component.restrictChildren.body.withContent = 'unknown';
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Additional property "withContent" of property "restrictChildren.body" of component "slider" points to non existing directive key "unknown" of component "body"`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Additional property "withContent" of property "restrictChildren.body" of component "slider" points to non existing directive key "unknown" of component "body"`);
         });
         it('should not pass if restrictChildren property points to the parent component', () => {
             definition.components.slider.component.restrictChildren.slider = {};
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Component property "restrictChildren.slider" of component "slider" points to itself`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Component property "restrictChildren.slider" of component "slider" points to itself`);
         });
         it('should not pass if restrictChildren property points to non existing component', () => {
             definition.components.slider.component.restrictChildren.unknown = {};
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Component property "restrictChildren.unknown" of component "slider" points to non existing component`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Component property "restrictChildren.unknown" of component "slider" points to non existing component`);
         });
         it('should not pass if restrictChildren property points to more then one component', () => {
             definition.components.slider.component.restrictChildren.intro = {};
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Component property "restrictChildren" of component "slider" must contain only one entry because the component contains a slideshow directive`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Component property "restrictChildren" of component "slider" must contain only one entry because the component contains a slideshow directive`);
         });
     });
 });

--- a/test/validators/scripts-validator.test.ts
+++ b/test/validators/scripts-validator.test.ts
@@ -2,36 +2,32 @@ import * as path from 'path';
 import { ScriptsValidator } from '../../lib/validators/scripts-validator';
 
 describe('ScriptsValidator', () => {
+    let error: jasmine.Spy;
+    beforeEach(() => {
+        error = jasmine.createSpy('error');
+    });
     describe('validate', () => {
-        let reporter: jasmine.Spy;
-        beforeEach(() => {
-            reporter = jasmine.createSpy('reporter');
-        });
         it('should pass on valid definition', () => {
-            const validator = new ScriptsValidator(new Set<string>([
+            const validator = new ScriptsValidator(error, new Set<string>([
                 path.normalize('scripts/vendor.js'),
             ]), <any>{
                 scripts: ['scripts/vendor.js'],
             });
-            const valid = validator.validate(reporter);
-            expect(reporter).not.toHaveBeenCalled();
-            expect(valid).toBeTruthy();
+            validator.validate();
+            expect(error).not.toHaveBeenCalled();
         });
         it('should pass when scripts is missing', () => {
-            const validator = new ScriptsValidator(new Set<string>([]), <any>{});
-            const valid = validator.validate(reporter);
-            expect(reporter).not.toHaveBeenCalled();
-            expect(valid).toBeTruthy();
+            const validator = new ScriptsValidator(error, new Set<string>([]), <any>{});
+            validator.validate();
+            expect(error).not.toHaveBeenCalled();
         });
         it('should not pass if "vendor.js" is missing', () => {
-            const validator = new ScriptsValidator(new Set<string>([
+            const validator = new ScriptsValidator(error, new Set<string>([
             ]), <any>{
                 scripts: ['scripts/vendor.js'],
             });
-
-            const valid = validator.validate(reporter);
-            expect(reporter).toHaveBeenCalledWith(`Script "scripts/vendor.js" does not exist`);
-            expect(valid).toBeFalsy();
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Script "scripts/vendor.js" does not exist`);
         });
     });
 });

--- a/test/validators/slides-validator.test.ts
+++ b/test/validators/slides-validator.test.ts
@@ -2,6 +2,7 @@ import { SlidesValidator } from '../../lib/validators/slides-validator';
 
 describe('SlidesValidator', () => {
     let definition: any;
+    let error: jasmine.Spy;
     let validator: SlidesValidator;
     beforeEach(() => {
         // valid definition (cut)
@@ -38,52 +39,43 @@ describe('SlidesValidator', () => {
                 },
             },
         };
-        validator = new SlidesValidator(definition);
+        error = jasmine.createSpy('error');
+        validator = new SlidesValidator(error, definition);
     });
     describe('validate', () => {
-        let reporter: jasmine.Spy;
-        beforeEach(() => {
-            reporter = jasmine.createSpy('reporter');
-        });
         it('should pass on valid definition', () => {
-            const valid = validator.validate(reporter);
-            expect(valid).toBeTruthy();
-            expect(reporter).not.toHaveBeenCalled();
+            validator.validate();
+            expect(error).not.toHaveBeenCalled();
         });
 
         it('should pass on valid definition with include', () => {
             definition.components.c1.properties[0].control.include = ['p2'];
-            const valid = validator.validate(reporter);
-            expect(valid).toBeTruthy();
-            expect(reporter).not.toHaveBeenCalled();
+            validator.validate();
+            expect(error).not.toHaveBeenCalled();
         });
 
         it('should pass on valid definition with exclude', () => {
             definition.components.c1.properties[0].control.exclude = ['p3'];
-            const valid = validator.validate(reporter);
-            expect(valid).toBeTruthy();
-            expect(reporter).not.toHaveBeenCalled();
+            validator.validate();
+            expect(error).not.toHaveBeenCalled();
         });
 
         it('should not pass if include has an invalid property', () => {
             definition.components.c1.properties[0].control.include = ['p_invalid'];
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith('Property \"p1\" is referring to an invalid property \"p_invalid\"not part of \"c2\"');
+            validator.validate();
+            expect(error).toHaveBeenCalledWith('Property \"p1\" is referring to an invalid property \"p_invalid\"not part of \"c2\"');
         });
 
         it('should not pass if exclude has an invalid property', () => {
             definition.components.c1.properties[0].control.exclude = ['p_invalid'];
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith('Property \"p1\" is referring to an invalid property \"p_invalid\"not part of \"c2\"');
+            validator.validate();
+            expect(error).toHaveBeenCalledWith('Property \"p1\" is referring to an invalid property \"p_invalid\"not part of \"c2\"');
         });
 
         it('should require restrictChildren to be set on slideshow component', () => {
             definition.components.c1.component.restrictChildren = null;
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith('Component \"c1\" must have restrictChildren set to use the slides property');
+            validator.validate();
+            expect(error).toHaveBeenCalledWith('Component \"c1\" must have restrictChildren set to use the slides property');
         });
     });
 });

--- a/test/validators/unit-type-validator.test.ts
+++ b/test/validators/unit-type-validator.test.ts
@@ -2,6 +2,7 @@ import { UnitTypeValidator } from '../../lib/validators/unit-type-validator';
 
 describe('UnitTypeValidator', () => {
     let definition: any;
+    let error: jasmine.Spy;
     let validator: UnitTypeValidator;
     beforeEach(() => {
         // valid definition (cut)
@@ -25,23 +26,18 @@ describe('UnitTypeValidator', () => {
                 },
             }]
         };
-        validator = new UnitTypeValidator(definition);
+        error = jasmine.createSpy('error');
+        validator = new UnitTypeValidator(error, definition);
     });
     describe('validate', () => {
-        let reporter: jasmine.Spy;
-        beforeEach(() => {
-            reporter = jasmine.createSpy('reporter');
-        });
         it('should pass on valid definition', () => {
-            const valid = validator.validate(reporter);
-            expect(valid).toBeTruthy();
-            expect(reporter).not.toHaveBeenCalled();
+            validator.validate();
+            expect(error).not.toHaveBeenCalled();
         });
         it('should not pass if unit type is unknown', () => {
             definition.componentProperties[1].control.unit = 'xy';
-            const valid = validator.validate(reporter);
-            expect(valid).toBeFalsy();
-            expect(reporter).toHaveBeenCalledWith(`Property "p2" has unaccaptable unit type "xy", only "em,px" are allowed`);
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(`Property "p2" has unaccaptable unit type "xy", only "em,px" are allowed`);
         });
     });
 });


### PR DESCRIPTION
…ue from the validator classes. Instead calling the validator class "error" function is enough. Simplifies writing tests, as the implementator only needs to to test if the error function is called.

Main goal is to simplify the validator classes a bit by not having to return a boolean value, but only call the error function. Makes testing easier as well.