### PR TITLE
ECS-368: Extract top level package validation in a static method

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,19 @@ const errorReporter = (errorMessage: string) => console.error(errorMessage);
 const validationResult: boolean = await validate(filePaths, getFileContent, errorReporter);
 ```
 
+### validatePackageSize
+
+Specific validation of the total maximum size of the component set (in bytes). This method can optionally be used as a quick fail-fast validation before running `validate` or `validateFolder`, which both run a full validation on the component set.
+
+```ts
+import { validatePackageSize } from './lib/index';
+
+const packageSize = (await fs.promises.stat('path/to/component-set.zip')).size;
+const errorReporter = (errorMessage: string) => console.error(errorMessage);
+
+const validationResult: boolean = await validatePackageSize(packageSize, errorReporter);
+```
+
 ### parser
 
 If published version (from "dist" folder) of the package is used then:

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -50,6 +50,7 @@ import {
     PackageValidator,
 } from './validators';
 import { listFilesRelativeToFolder } from './util/files';
+import { validateTotalSize } from './validators/package-validator';
 
 const ajv = new Ajv({ allErrors: true, jsonPointers: true, verbose: true });
 
@@ -170,6 +171,21 @@ export async function validate(
     }
 
     return valid;
+}
+
+/**
+ * Validates the total file size of the component set package.
+ *
+ * @param size component set package size in bytes
+ * @param errorReporter called when there is a validation error
+ */
+export function validatePackageSize(size: number, errorReporter: (errorMessage: string) => void) {
+    const error = validateTotalSize(size);
+    if (error) {
+        errorReporter(error);
+        return false;
+    }
+    return true;
 }
 
 async function getComponentsDefinition(

--- a/lib/validators/package-validator.ts
+++ b/lib/validators/package-validator.ts
@@ -44,21 +44,11 @@ export class PackageValidator extends Validator {
         this.validateCustomData(files);
     }
 
-    static validateSize(size: number) {
-        const sizeMB = Math.round(size / MB_IN_BYTES);
-        if (sizeMB > MAX_COMPONENT_SET_SIZE_MB) {
-            throw new Error(
-                `At ${sizeMB}MB, the component set exceeds the total maximum size of ${MAX_COMPONENT_SET_SIZE_MB}MB.`,
-            );
-        }
-    }
-
     private validateComponentSetSize(files: FileInfo[]): void {
         const folderSize = this.calculateFolderSize(files);
-        try {
-            PackageValidator.validateSize(folderSize);
-        } catch (e) {
-            this.error(e.message);
+        const error = validateTotalSize(folderSize);
+        if (error) {
+            this.error(error);
         }
     }
 
@@ -97,5 +87,12 @@ export class PackageValidator extends Validator {
         return files.reduce((acc, file) => {
             return acc + file.size;
         }, 0);
+    }
+}
+
+export function validateTotalSize(size: number): string | undefined {
+    const sizeMB = Math.round(size / MB_IN_BYTES);
+    if (sizeMB > MAX_COMPONENT_SET_SIZE_MB) {
+        return `At ${sizeMB}MB, the component set exceeds the total maximum size of ${MAX_COMPONENT_SET_SIZE_MB}MB.`;
     }
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,4 +1,4 @@
-import { validateFolder, getValidators } from '../lib/index';
+import { validateFolder, getValidators, validatePackageSize } from '../lib/index';
 import * as colors from 'colors/safe';
 
 describe('validateFolder', () => {
@@ -29,6 +29,20 @@ describe('validateFolder', () => {
         expect(global.console.log).toHaveBeenCalledWith(
             expect.stringMatching('Components definition file "components-definition.json" is not valid json:'),
         );
+    });
+});
+
+describe('validatePackageSize', () => {
+    it('should pass when the component set is within size limts', async () => {
+        const errorMessages: string[] = [];
+        validatePackageSize(99 * 1000 * 1000, (errorMessage) => errorMessages.push(errorMessage));
+        expect(errorMessages.length).toBe(0);
+    });
+    it('should fail when the component set is too large', async () => {
+        const errorMessages: string[] = [];
+        validatePackageSize(101 * 1000 * 1000, (errorMessage) => errorMessages.push(errorMessage));
+        expect(errorMessages.length).toBe(1);
+        expect(errorMessages[0]).toMatch('At 101MB, the component set exceeds the total maximum size of 100MB.');
     });
 });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -33,7 +33,7 @@ describe('validateFolder', () => {
 });
 
 describe('validatePackageSize', () => {
-    it('should pass when the component set is within size limts', async () => {
+    it('should pass when the component set is within size limits', async () => {
         const errorMessages: string[] = [];
         validatePackageSize(99 * 1000 * 1000, (errorMessage) => errorMessages.push(errorMessage));
         expect(errorMessages.length).toBe(0);


### PR DESCRIPTION
Static validateSize method is to be used in ecs-backed directly to validate the size of the zip file before unpacking it.