### PR TITLE
Feature/rename project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# csde-components-validator
+# studio-component-set-tools
 
-Validation module for Content Station Digital Editor component sets.
+Tools module for Studio Digital Editor component sets.
 
 ## Usage
 
-The module provides two public api methods for validating a component set.
+The module provides tooling to develop component sets. It contains two public api methods for validating a component set.
 
 ### validateFolder
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Tools module for Studio Digital Editor component sets.
 
 ## Usage
 
-The module provides tooling to develop component sets. It contains two public api methods for validating a component set.
+The module provides tooling to develop component sets. It contains for example public API methods for validating a component set.
 
 ### validateFolder
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Tools module for Studio Digital Editor component sets.
 
 ## Usage
 
-The module provides tooling to develop component sets. It contains for example public API methods for validating a component set.
+The module provides tooling to develop component sets. For example, it contains public API methods to validate a component set.
 
 ### validateFolder
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "@woodwing/csde-components-validator",
-  "version": "1.10.1",
+  "name": "@woodwing/studio-component-set-tools",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@woodwing/csde-components-validator",
-  "version": "1.10.1",
+  "name": "@woodwing/studio-component-set-tools",
+  "version": "1.0.0",
   "description": "Validation module for Content Station Digital Editor components packages.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -22,14 +22,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/WoodWing/csde-components-validator.git"
+    "url": "git+https://github.com/WoodWing/studio-component-set-tools.git"
   },
   "author": "",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/WoodWing/csde-components-validator/issues"
+    "url": "https://github.com/WoodWing/studio-component-set-tools/issues"
   },
-  "homepage": "https://github.com/WoodWing/csde-components-validator#readme",
+  "homepage": "https://github.com/WoodWing/studio-component-set-tools#readme",
   "devDependencies": {
     "@types/htmlparser2": "3.7.31",
     "@types/jest": "^26.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@woodwing/studio-component-set-tools",
   "version": "1.0.0",
-  "description": "Validation module for Content Station Digital Editor components packages.",
+  "description": "Tools module for Studio Digital Editor component sets packages.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [


### PR DESCRIPTION
I propose that we rename this repo/library to `studio-component-set-tools` so we can add more generic tools to the library besides the validation. 

As there is no real renaming solution for NPM we could deprecate the current `csde-components-validator` package on NPM as described here: https://stackoverflow.com/questions/28371669/renaming-a-published-npm-module

I've also reset the version to 1.0.0 as this is a new package. Although I'm not sure if that is something we want. 

When this PR is merged we should also update the repo name itself in GitHub. As far as I can see this should not have any impact as customers can still download the 'old' validator from NPM and builds are created manually. 