### PR TITLE
Feature/eslint test fixes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,4 +11,12 @@ module.exports = {
         '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
         'object-shorthand': ['error', 'never'],
     },
+    overrides: [
+        {
+            files: ['./test/**/*'],
+            rules: {
+                '@typescript-eslint/no-explicit-any': 'off',
+            },
+        },
+    ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1094,6 +1094,15 @@
       "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==",
       "dev": true
     },
+    "@types/lodash.clonedeep": {
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz",
+      "integrity": "sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/lodash.merge": {
       "version": "4.6.6",
       "resolved": "https://registry.npmjs.org/@types/lodash.merge/-/lodash.merge-4.6.6.tgz",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "@types/htmlparser2": "3.7.31",
     "@types/jest": "^26.0.0",
+    "@types/lodash.clonedeep": "^4.5.6",
     "@types/lodash.merge": "^4.6.6",
     "@types/node": "^12.12.6",
     "@types/pngjs": "^6.0.0",

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,5 @@
 import { validateFolder, getValidators, validatePackageSize } from '../lib/index';
-import * as colors from 'colors/safe';
+import colors from 'colors/safe';
 
 describe('validateFolder', () => {
     it('should pass on minimal sample', async () => {
@@ -20,15 +20,15 @@ describe('validateFolder', () => {
         expect(global.console.log).toHaveBeenCalledWith(
             colors.red(`/components/0 should NOT have additional properties
 {
-    \"additionalProperty\": \"invalid-component-property\"
+    "additionalProperty": "invalid-component-property"
 }
 components-definition.json - line 7, column 8:
 >         {
->             \"name\": \"body\",
->             \"label\": \"Body Label\",
->             \"icon\": \"icons/component.svg\",
->             \"properties\": [],
->             \"invalid-component-property\": \"Invalid component property\"
+>             "name": "body",
+>             "label": "Body Label",
+>             "icon": "icons/component.svg",
+>             "properties": [],
+>             "invalid-component-property": "Invalid component property"
 `),
         );
     });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,5 @@
 import { validateFolder, getValidators, validatePackageSize } from '../lib/index';
-import colors from 'colors/safe';
+import * as colors from 'colors/safe';
 
 describe('validateFolder', () => {
     it('should pass on minimal sample', async () => {

--- a/test/parser/parser-util.test.ts
+++ b/test/parser/parser-util.test.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import { parseDefinition } from '../../lib/parser/parser-utils';
 import { DirectiveType, ComponentRendition } from '../../lib/models';
-const cloneDeep = require('lodash.clonedeep');
+import cloneDeep from 'lodash.clonedeep';
 
 describe('Parser utils', () => {
     describe('parseDefinition', () => {

--- a/test/parser/parser-util.test.ts
+++ b/test/parser/parser-util.test.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import { parseDefinition } from '../../lib/parser/parser-utils';
 import { DirectiveType, ComponentRendition } from '../../lib/models';
-import cloneDeep from 'lodash.clonedeep';
+import cloneDeep = require('lodash.clonedeep');
 
 describe('Parser utils', () => {
     describe('parseDefinition', () => {

--- a/test/validators/autofill-validator.test.ts
+++ b/test/validators/autofill-validator.test.ts
@@ -73,7 +73,7 @@ describe('AutofillValidator', () => {
             definition.components.c2.directiveOptions.title.autofill.source = 'editable';
             validator.validate();
             expect(error).toHaveBeenCalledWith(
-                `Component \"c2\" has incorrect autofill rule \"title\". This component doesn't have directive \"editable\".`,
+                `Component "c2" has incorrect autofill rule "title". This component doesn't have directive "editable".`,
             );
         });
         it('should not pass if source directive is image and metadataField is not set', () => {

--- a/test/validators/doc-container-groups-validator.test.ts
+++ b/test/validators/doc-container-groups-validator.test.ts
@@ -52,7 +52,7 @@ describe('DocContainerGroupsValidator', () => {
 
             validator.validate();
 
-            expect(error).toHaveBeenCalledWith(`Component \"c1\" has a group for invalid directive \"main\"`);
+            expect(error).toHaveBeenCalledWith(`Component "c1" has a group for invalid directive "main"`);
         });
 
         it('should fail validation for invalid directive type', () => {
@@ -63,7 +63,7 @@ describe('DocContainerGroupsValidator', () => {
             validator.validate();
 
             expect(error).toHaveBeenCalledWith(
-                `Component \"c1\" has a group for directive \"main\" with incompatible type \"editable\". Only type \"container\" is allowed.`,
+                `Component "c1" has a group for directive "main" with incompatible type "editable". Only type "container" is allowed.`,
             );
         });
 
@@ -75,7 +75,7 @@ describe('DocContainerGroupsValidator', () => {
 
             validator.validate();
 
-            expect(error).toHaveBeenCalledWith(`Component \"picture\" of group \"g1\" does not exist`);
+            expect(error).toHaveBeenCalledWith(`Component "picture" of group "g1" does not exist`);
         });
     });
 });

--- a/test/validators/doc-media-validator.test.ts
+++ b/test/validators/doc-media-validator.test.ts
@@ -54,7 +54,7 @@ describe('DocMediaValidator', () => {
 
             validator.validate();
             expect(error).toHaveBeenCalledWith(
-                `Component \"socialmedia\" with \"doc-media\" directive must have exactly one \"media-properties\" property (found 0)`,
+                `Component "socialmedia" with "doc-media" directive must have exactly one "media-properties" property (found 0)`,
             );
         });
         it('should pass with one media directives and other directive types', () => {
@@ -76,7 +76,7 @@ describe('DocMediaValidator', () => {
             };
             validator.validate();
             expect(error).toHaveBeenCalledWith(
-                `Component \"socialmedia\" can only have one \"doc-media\" directive in the HTML definition`,
+                `Component "socialmedia" can only have one "doc-media" directive in the HTML definition`,
             );
         });
         it('should fail if a component property with a media-properties control type is not applied to a media directive', () => {
@@ -105,7 +105,7 @@ describe('DocMediaValidator', () => {
             };
             validator.validate();
             expect(error).toHaveBeenCalledWith(
-                `Component \"wrongdirectivekey\" has a control type \"media-properties\" applied to the wrong directive, which can only be used with \"doc-media\" directives`,
+                `Component "wrongdirectivekey" has a control type "media-properties" applied to the wrong directive, which can only be used with "doc-media" directives`,
             );
         });
         it('should fail in case a "media-properties" property does not have a directive key', () => {
@@ -129,7 +129,7 @@ describe('DocMediaValidator', () => {
             };
             validator.validate();
             expect(error).toHaveBeenCalledWith(
-                `Component \"nodirectivekey\" must configure \"directiveKey\" for the property with control type \"media-properties\"`,
+                `Component "nodirectivekey" must configure "directiveKey" for the property with control type "media-properties"`,
             );
         });
 
@@ -147,7 +147,7 @@ describe('DocMediaValidator', () => {
 
             validator.validate();
             expect(error).toHaveBeenCalledWith(
-                `Component \"body\" has a \"media-properties\" control type, but only components with a \"doc-media\" directive can have a property with this control type`,
+                `Component "body" has a "media-properties" control type, but only components with a "doc-media" directive can have a property with this control type`,
             );
         });
     });


### PR DESCRIPTION
This PR is based on the feature/eslint-lib-fixes branch. It fixes all the eslint errors in the `./test` folder. Only for the `./test` folder the `@typescript-eslint/no-explicit-any` rule is turned off as the Component Set interfaces aren't entirely correct. So fixing this became time consuming. Another reason to disable this rule for tests is that partial test objects first need to be casted to unknown and then to the ComponentSet type for example. Not sure if this is something that we want. 