### PR TITLE
CSH-10526: fix entry point warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,11 +15,11 @@ jobs:
             CI: true
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
-            - uses: actions/setup-node@v3
+            - uses: actions/setup-node@v4
               with:
-                  node-version: 16
+                  node-version: 20
 
             - uses: bahmutov/npm-install@v1
 

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -11,11 +11,11 @@ jobs:
             CI: true
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
-            - uses: actions/setup-node@v3
+            - uses: actions/setup-node@v4
               with:
-                  node-version: 16
+                  node-version: 20
 
             - uses: bahmutov/npm-install@v1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,11 @@ jobs:
     release:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
-            - uses: actions/setup-node@v3
+            - uses: actions/setup-node@v4
               with:
-                  node-version: 16
+                  node-version: 20
 
             - uses: bahmutov/npm-install@v1
 
@@ -26,10 +26,10 @@ jobs:
 
             # https://docs.github.com/en/actions/guides/publishing-nodejs-packages#publishing-packages-to-npm-and-github-packages
             # Setup .npmrc file to publish to GitHub Packages (can replace the other setup-node action when we no longer publish to npm)
-            - uses: actions/setup-node@v3
+            - uses: actions/setup-node@v4
               with:
                   registry-url: 'https://npm.pkg.github.com'
-                  node-version: 16
+                  node-version: 20
             # Publish to GitHub Packages
             - run: npm publish --access public
               env:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,5 @@
         "noImplicitReturns": true,
         "noFallthroughCasesInSwitch": true
     },
-    "include": ["./lib/**/*"]
+    "files": ["./lib/validate.ts", "./lib/utils.ts"]
 }


### PR DESCRIPTION
CSH-10526: with the upgraded toolchain for the Angular 19 we started to see warnings in the console. This change hopefully fixes those.

<img width="418" alt="image" src="https://github.com/user-attachments/assets/b20e2634-3f49-4aef-b703-b55a9544a664" />


Also upgrade node and action versions